### PR TITLE
feat: 6スライドPPTX生成 + UI拡充 + SK 1.42互換性とハードニング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ htmlcov/
 
 # OS
 .DS_Store
+
+# Claude Code (session cache, worktree metadata)
+.claude/

--- a/agent-first-meeting/README.md
+++ b/agent-first-meeting/README.md
@@ -10,9 +10,118 @@
 - **LLM**: GPT-4.1（Azure OpenAI on Foundry にデプロイ）
 - **埋め込みモデル**: text-embedding-3-large
 - **データストア**: Azure Cosmos DB（顧客・面談・事例 + Vector Search）
-- **資料生成**: python-pptx（MVP は表紙1枚のみ）
+- **資料生成**: python-pptx（6 スライド構成：表紙 / 目次 / 業界向け / 役職向け / 自社商品 / 費用）
 - **出力ストレージ**: Azure Blob Storage
 - **デプロイ先**: Azure Container Apps
+
+## システム構成図
+
+```mermaid
+flowchart LR
+    User[営業担当者]
+
+    subgraph Frontend["Streamlit フロント"]
+        UI["frontend/main.py<br/>入力フォーム + SSE 表示"]
+    end
+
+    subgraph Backend["FastAPI バックエンド (agent-first-meeting)"]
+        API["api.py<br/>POST /api/first-meeting/generate<br/>SSE: thought / tool / tool_result / message / done"]
+        Agent["agent.py<br/>FirstMeetingAgent<br/>(Semantic Kernel ChatCompletionAgent)<br/>FunctionChoiceBehavior.Auto"]
+
+        subgraph Plugins["SK Plugins (kernel_function)"]
+            P1["CustomerHistoryPlugin<br/>get_customer_history"]
+            P2["CaseSearchPlugin<br/>search_similar_cases"]
+            P3["DocumentGenPlugin<br/>generate_pptx"]
+            P4["MeetingRecordPlugin<br/>save_meeting_record"]
+        end
+    end
+
+    subgraph Azure["Azure (East US 2)"]
+        subgraph Foundry["Azure AI Foundry"]
+            Chat["gpt-4.1<br/>(chat deployment)"]
+            Emb["text-embedding-3-large<br/>dimensions=1536"]
+        end
+
+        subgraph Cosmos["Cosmos DB for NoSQL — sales-agent"]
+            C1[("customers<br/>/companyId")]
+            C2[("meetings<br/>/companyId")]
+            C3[("documents<br/>/companyId")]
+            C4[("cases<br/>/industry<br/>+ Vector Index (DiskANN)")]
+        end
+
+        Blob[("Blob Storage<br/>generated-documents<br/>proposals/*.pptx")]
+    end
+
+    User --> UI
+    UI -- "httpx SSE" --> API
+    API --> Agent
+    Agent <--> Chat
+    Agent --> P1 & P2 & P3 & P4
+
+    P1 -- "SELECT companyName" --> C1
+    P1 -- "ORDER BY round DESC" --> C2
+    P2 -- "embed query" --> Emb
+    P2 -- "VectorDistance ORDER BY" --> C4
+    P3 -- "python-pptx upload + SAS 24h" --> Blob
+    P4 -- "upsert (new company)" --> C1
+    P4 -- "upsert record (outcomes=null)" --> C2
+```
+
+## 実行フロー
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Sales as 営業担当者
+    participant UI as Streamlit
+    participant API as FastAPI<br/>(api.py)
+    participant Agent as FirstMeetingAgent<br/>(SK + gpt-4.1)
+    participant Cosmos as Cosmos DB
+    participant Emb as text-embedding-3-large
+    participant Blob as Blob Storage
+
+    Sales->>UI: 会社名/業種/規模/課題感を入力
+    UI->>API: POST /api/first-meeting/generate
+    API->>Agent: invoke_stream(user_message)
+
+    Note over Agent: auto function calling
+
+    Agent->>Cosmos: get_customer_history(companyName)
+    Cosmos-->>Agent: {customer, meetings[]} or null
+
+    Agent->>Emb: embeddings.create(query, dim=1536)
+    Emb-->>Agent: vector[1536]
+    Agent->>Cosmos: search_similar_cases<br/>(VectorDistance TOP 3)
+    Cosmos-->>Agent: cases[] with score
+
+    Note over Agent: 履歴 + 類似事例から<br/>提案タイトル生成
+
+    Agent->>Blob: generate_pptx(title, subtitle)
+    Blob-->>Agent: SAS 付き URL (24h)
+
+    Agent->>Cosmos: save_meeting_record<br/>(新規なら customers にも upsert)
+    Cosmos-->>Agent: meeting id (mtg_xxx)
+
+    Agent-->>API: streaming (tool / tool_result / message)
+    API-->>UI: SSE events
+    UI-->>Sales: PPTX URL + 提案根拠 + 次回アクション
+```
+
+## エージェントの判断ロジック
+
+```mermaid
+flowchart TD
+    Start([顧客情報受領]) --> H[get_customer_history]
+    H --> Q{customer == null?}
+    Q -- "新規" --> S[search_similar_cases<br/>業界/規模/課題で自然文検索]
+    Q -- "既存" --> S2["前回 outcomes / nextActions を加味<br/>+ search_similar_cases"]
+    S --> T[提案タイトルを 1 つ考案<br/>事例の成果に言及]
+    S2 --> T
+    T --> G[generate_pptx<br/>表紙のみの PowerPoint]
+    G --> R[save_meeting_record<br/>outcomes=null で書き出し]
+    R --> Report["ユーザーへ報告<br/>履歴有無 / URL / タイトル根拠 /<br/>確認ポイント / レコード ID"]
+    Report --> End([follow-up エージェントへ引き継ぎ])
+```
 
 ## ディレクトリ構成
 
@@ -50,13 +159,33 @@ cp .env.example .env
 
 ## エージェントのツール構成
 
-| # | ツール名 | 役割 |
+エージェントは以下の Semantic Kernel プラグインを `FunctionChoiceBehavior.Auto` で自律的に呼び出します。
+
+| # | ツール名 | プラグイン | 役割 |
+|---|---|---|---|
+| ① | `get_customer_history` | `CustomerHistoryPlugin` | `customers` / `meetings` から過去情報取得 |
+| ② | `search_similar_cases` | `CaseSearchPlugin` | `cases` コンテナを vector 検索（TOP N, DiskANN） |
+| ③ | `fetch_url_text` | `WebFetchPlugin` | 顧客 HP の URL を取得し本文テキスト化（最大4000字） |
+| ④ | `generate_pptx` | `DocumentGenPlugin` | 6 スライド PPTX 生成 → Blob アップロード（SAS 24h） |
+| ⑤ | `save_meeting_record` | `MeetingRecordPlugin` | `meetings` に upsert（follow-up エージェントへの引き継ぎ） |
+
+## テスト
+
+純粋ロジック（PPTX 組み立て / スキーマ / HTML→テキスト変換）は Azure / Semantic Kernel に依存せず単独で実行できます。
+
+```bash
+# 依存をインストール（一度だけ）
+pip install -e ".[dev]"
+
+# テスト実行
+pytest tests/ -v
+```
+
+| テストファイル | 対象 | 依存 |
 |---|---|---|
-| ① | `search_similar_cases` | Cosmos DB の `cases` コンテナを vector + filter で検索 |
-| ② | `get_customer_history` | `customers` / `meetings` から過去情報取得 |
-| ③ | `draft_proposal_outline` | LLM がアウトライン JSON を生成 |
-| ④ | `generate_pptx` | python-pptx でテンプレ穴埋め → Blob にアップロード |
-| ⑤ | `save_meeting_record` | `meetings` コンテナに記録（follow-up エージェントへの引き継ぎ） |
+| `tests/test_pptx_builder.py` | `_pptx_builder.build_presentation_bytes` の 6 スライド構造 | `python-pptx` のみ |
+| `tests/test_schemas.py` | `GenerateRequest` バリデーション / `to_user_message` 整形 | `pydantic` のみ |
+| `tests/test_html_to_text.py` | `_html_to_text.strip_html` の HTML 整形 | `beautifulsoup4` のみ |
 
 ## API
 

--- a/agent-first-meeting/pyproject.toml
+++ b/agent-first-meeting/pyproject.toml
@@ -15,13 +15,15 @@ dependencies = [
     "azure-identity",     # Azure 認証（Managed Identity / DefaultAzureCredential）
     "python-pptx",        # PowerPoint 資料生成
     "pydantic-settings",  # 環境変数の管理
+    "httpx",              # WebFetchPlugin が顧客 HP を取得するために使用
+    "beautifulsoup4",     # WebFetchPlugin が HTML を本文テキスト化するために使用
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest",            # テストフレームワーク
     "pytest-asyncio",    # 非同期テスト対応
-    "httpx",             # FastAPI テスト用クライアント
+    # httpx は本番 deps に入っているので dev では不要
     "ruff",              # コードフォーマッター・Linter
 ]
 

--- a/agent-first-meeting/scripts/seed_customer.py
+++ b/agent-first-meeting/scripts/seed_customer.py
@@ -2,20 +2,28 @@
 
 「既存顧客」シナリオで get_customer_history が履歴を返せるよう、
 1 件の customer + 過去 1 件の meeting を seed する。
+
+companyId は `_deterministic_company_id` から動的に計算するので、
+MeetingRecordPlugin が後から save しても同じ companyId で続きの round
+が積まれる。
 """
 import sys
 
 from azure.cosmos import CosmosClient
 
+from agent_first_meeting._company_id import deterministic_company_id
 from agent_first_meeting.config import settings
 
 sys.stdout.reconfigure(encoding="utf-8")
 
 
+COMPANY_NAME = "株式会社既存お得意様"
+COMPANY_ID = deterministic_company_id(COMPANY_NAME)
+
 CUSTOMER = {
-    "id": "cus_existing01",
-    "companyId": "cus_existing01",
-    "companyName": "株式会社既存お得意様",
+    "id": COMPANY_ID,
+    "companyId": COMPANY_ID,
+    "companyName": COMPANY_NAME,
     "industry": "製造業",
     "scale": "中小企業",
     "knownChallenges": ["人材不足", "原材料費高騰", "技能継承"],
@@ -25,8 +33,8 @@ CUSTOMER = {
 }
 
 PRIOR_MEETING = {
-    "id": "mtg_prior01",
-    "companyId": "cus_existing01",
+    "id": f"mtg_{COMPANY_ID}_0001",
+    "companyId": COMPANY_ID,
     "round": 1,
     "scheduledAt": "2026-01-15T10:00:00Z",
     "status": "done",

--- a/agent-first-meeting/src/agent_first_meeting/_company_id.py
+++ b/agent-first-meeting/src/agent_first_meeting/_company_id.py
@@ -1,0 +1,17 @@
+"""会社名から決定的に companyId を導出する共有ユーティリティ.
+
+ここを 1 箇所にまとめることで、`MeetingRecordPlugin` と seed スクリプトが
+同じ計算式を使えることを保証する。
+"""
+import hashlib
+
+
+def deterministic_company_id(company_name: str) -> str:
+    """会社名 → 決定的 companyId（`cus_` + SHA1 先頭12文字）.
+
+    並行作成のレースを避けるため、同じ会社名は必ず同じ ID になるように決定的に算出。
+    SHA1 を使うのは「短くて衝突確率が事実上ゼロ」だから。暗号学的強度は要求していない。
+    """
+    normalized = company_name.strip()
+    digest = hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"cus_{digest}"

--- a/agent-first-meeting/src/agent_first_meeting/agent.py
+++ b/agent-first-meeting/src/agent_first_meeting/agent.py
@@ -1,4 +1,6 @@
-"""初回面談エージェントのファクトリ."""
+"""初回面談 / 2回目以降の面談エージェントのファクトリ."""
+import logging
+
 from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.connectors.ai.function_choice_behavior import (
     FunctionChoiceBehavior,
@@ -7,6 +9,7 @@ from semantic_kernel.connectors.ai.open_ai import (
     AzureChatCompletion,
     OpenAIChatPromptExecutionSettings,
 )
+from semantic_kernel.filters import FilterTypes
 from semantic_kernel.functions import KernelArguments
 
 from agent_first_meeting.config import settings
@@ -14,25 +17,82 @@ from agent_first_meeting.tools.case_search import CaseSearchPlugin
 from agent_first_meeting.tools.customer_history import CustomerHistoryPlugin
 from agent_first_meeting.tools.document_gen import DocumentGenPlugin
 from agent_first_meeting.tools.meeting_record import MeetingRecordPlugin
+from agent_first_meeting.tools.web_fetch import WebFetchPlugin
+
+logger = logging.getLogger(__name__)
 
 
-AGENT_INSTRUCTIONS = """\
+class ToolResultTracker:
+    """エージェントが呼んだツールと、特定のツール結果を集める Filter.
+
+    SK 1.42 の `invoke_stream` では FunctionCallContent / FunctionResultContent
+    が streaming items として流れない（最終テキスト応答のみ流れる）ため、
+    Filter で kernel function 呼び出しをフックして必要な結果を集める。
+    """
+
+    def __init__(self) -> None:
+        self.invoked_tools: set[str] = set()
+        self.document_url: str | None = None
+        self.meeting_id: str | None = None
+
+    async def hook(self, context, next):  # noqa: A002 (SK API は kw 名 'next' を要求)
+        await next(context)
+        try:
+            fn_name = context.function.name
+        except Exception:  # noqa: BLE001
+            return
+        self.invoked_tools.add(fn_name)
+        try:
+            result_obj = context.result
+            # SK の FunctionResult は .value 経由でアクセス
+            val = None
+            if result_obj is not None:
+                if hasattr(result_obj, "value"):
+                    val = result_obj.value
+                else:
+                    val = result_obj
+                # FunctionResult.value がリストの場合もある
+                if isinstance(val, list) and val:
+                    val = val[0]
+                val_str = str(val) if val is not None else None
+            else:
+                val_str = None
+            if fn_name == "generate_pptx" and val_str:
+                self.document_url = val_str
+                logger.info("ToolResultTracker: captured document_url len=%d", len(val_str))
+            elif fn_name == "save_meeting_record" and val_str:
+                self.meeting_id = val_str
+                logger.info("ToolResultTracker: captured meeting_id=%s", val_str)
+        except Exception:  # noqa: BLE001
+            logger.exception("ToolResultTracker: failed to extract result")
+
+
+FIRST_AGENT_INSTRUCTIONS = """\
 あなたは営業担当者の初回面談を支援する AI エージェントです。
 顧客情報を受け取ったら、以下の流れで動いてください。
 
 1. **get_customer_history** で過去の取引履歴を確認する
    - 既存顧客の場合は前回までの outcomes / nextActions を踏まえて提案を組み立てる
    - 新規顧客（customer=null）の場合は次のステップへ
-2. **search_similar_cases** で社内に蓄積された類似事例を最大 3 件取得する
+2. 顧客情報に「公式 HP」の URL が含まれている場合は **fetch_url_text** で
+   HP 本文を取得し、事業内容・サービス・直近ニュースから業界課題を推定する。
+   （URL が未記入なら飛ばしてよい）
+   返り値は JSON 文字列で {ok: bool, ...} の形。ok=false なら text として
+   利用してはならず、HP 情報なしで進める。
+3. **search_similar_cases** で社内に蓄積された類似事例を最大 3 件取得する
    （クエリは顧客の業界・規模・課題感を含めた自然文で組み立ててください）
-3. 顧客情報・履歴・類似事例を踏まえて、初回提案資料の表紙タイトルを 1 つ考案する
-   - 顧客の業界・規模・課題感が伝わる
-   - 類似事例の成果（例: 30%効率化）に触れると説得力が増す
-4. **generate_pptx** で表紙だけの提案資料を作成する
-5. **save_meeting_record** で生成資料と次回アクションを meetings コンテナに保存する
+4. 顧客情報・履歴・HP・類似事例を踏まえて、6 スライド構成の提案資料の素材を組み立てる
+   - **cover_title**: 顧客の業界・規模・課題感が伝わる表紙タイトル。類似事例の成果に触れると説得力が増す
+   - **cover_subtitle**: 「<会社名> 様向け / <年月> / 担当: <営業名>」の形式
+   - **industry_body**: 業界トレンドと顧客の課題を 3〜5 行の箇条書き（1 行 = 1 項目、改行区切り）
+   - **position_body**: 取引相手の役職（経営層 / 部門責任者 / 担当者）に響く論点を 3〜5 行の箇条書き
+   - ※ 自社商品スライドと費用スライドはプラグイン側で固定値（テスト商品 / 10 円）が入るので指定不要
+5. **generate_pptx** で 6 スライド（表紙 / 目次 / 業界向け / 役職向け / 自社商品 / 費用）の提案資料を作成する
+6. **save_meeting_record** で生成資料と次回アクションを meetings コンテナに保存する
    （これが follow-up エージェントへの引き継ぎ点）
-6. 最後にユーザー（営業担当者）に向けて、以下を簡潔にレポートする
+7. 最後にユーザー（営業担当者）に向けて、以下を簡潔にレポートする
    - 履歴の有無（新規 or 既存）と参照した過去面談の概要（あれば）
+   - HP 取得の有無と推定した事業特性（取得した場合）
    - 生成した資料の URL
    - 提案タイトルとその根拠（参照した事例）
    - 初回面談で確認すべきポイント
@@ -42,26 +102,65 @@ AGENT_INSTRUCTIONS = """\
 """
 
 
-def build_agent() -> ChatCompletionAgent:
-    """auto function calling 有効化済みの ChatCompletionAgent を返す."""
+# Phase 2 スケルトン：2回目以降の面談エージェント。
+# 中身は first と同じツール群を持つが、instructions だけ差し替えている。
+# 本実装は Phase 3 以降で詰める。
+FOLLOWUP_AGENT_INSTRUCTIONS = """\
+あなたは営業担当者の **2回目以降** の面談を支援する AI エージェントです。
+初回面談との違いは「前回までの outcomes と nextActions を必ず踏まえる」点です。
+
+1. **get_customer_history** で過去の取引履歴を必ず取得する
+   - meetings 配列が空なら、ユーザーに「初回面談を先に実施してください」と返して終了
+   - 直近の meeting の outcomes / nextActions を抽出する
+2. 必要に応じて **fetch_url_text** で HP を再取得（事業状況に変化がないか確認）
+3. 前回の nextActions を解決する提案を組み立て、必要なら
+   **search_similar_cases** で追加事例を取得
+4. **generate_pptx** で 6 スライド構成の継続提案資料を生成する。
+   industry_body / position_body は前回 outcomes を踏まえた論点で組み立てる。
+5. **save_meeting_record** で本回のレコードを保存（round は自動採番）
+6. ユーザーに対し、前回からの差分・今回の論点・次回アクションを報告
+
+※ このプロンプトは Phase 2 スケルトン。Phase 3 以降で本格的な
+継続提案ロジックに差し替える前提です。
+"""
+
+
+def _build(name: str, instructions: str) -> tuple[ChatCompletionAgent, ToolResultTracker]:
+    """両エージェント共通の組み立て処理. agent と tracker をペアで返す."""
     execution_settings = OpenAIChatPromptExecutionSettings(
         function_choice_behavior=FunctionChoiceBehavior.Auto(),
     )
 
-    return ChatCompletionAgent(
+    agent = ChatCompletionAgent(
         service=AzureChatCompletion(
             api_key=settings.azure_openai_api_key,
             endpoint=settings.azure_openai_endpoint,
             deployment_name=settings.azure_openai_chat_deployment,
             api_version=settings.azure_openai_api_version,
         ),
-        name="FirstMeetingAgent",
-        instructions=AGENT_INSTRUCTIONS,
+        name=name,
+        instructions=instructions,
         plugins=[
             CustomerHistoryPlugin(),
             CaseSearchPlugin(),
+            WebFetchPlugin(),
             DocumentGenPlugin(),
             MeetingRecordPlugin(),
         ],
         arguments=KernelArguments(settings=execution_settings),
     )
+
+    # Filter を kernel に登録して、ツール呼び出しの結果をフックする
+    tracker = ToolResultTracker()
+    agent.kernel.add_filter(FilterTypes.FUNCTION_INVOCATION, tracker.hook)
+    return agent, tracker
+
+
+def build_agent() -> tuple[ChatCompletionAgent, ToolResultTracker]:
+    """初回面談エージェント. (agent, tracker) を返す."""
+    return _build("FirstMeetingAgent", FIRST_AGENT_INSTRUCTIONS)
+
+
+def build_followup_agent() -> tuple[ChatCompletionAgent, ToolResultTracker]:
+    """2回目以降の面談エージェント（Phase 2 スケルトン）. (agent, tracker) を返す."""
+    return _build("FollowupMeetingAgent", FOLLOWUP_AGENT_INSTRUCTIONS)

--- a/agent-first-meeting/src/agent_first_meeting/api.py
+++ b/agent-first-meeting/src/agent_first_meeting/api.py
@@ -1,9 +1,9 @@
 """FastAPI アプリ：初回面談エージェントの SSE エンドポイント."""
 import json
+import logging
 import re
+from contextlib import asynccontextmanager
 from typing import AsyncGenerator
-
-PPTX_URL_PATTERN = re.compile(r"https://[^\s)\]」]+?\.pptx(?:\?[^\s)\]」]*)?")
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -14,10 +14,37 @@ from semantic_kernel.contents import (
 )
 from sse_starlette.sse import EventSourceResponse
 
-from agent_first_meeting.agent import build_agent
+from agent_first_meeting.agent import build_agent, build_followup_agent
+from agent_first_meeting.config import settings
+from agent_first_meeting.logging_config import setup_logging
 from agent_first_meeting.schemas import GenerateRequest, to_user_message
+from agent_first_meeting.tools.customer_history import CustomerHistoryPlugin
 
-app = FastAPI(title="agent-first-meeting", version="0.1.0")
+PPTX_URL_PATTERN = re.compile(r"https://[^\s)\]」]+?\.pptx(?:\?[^\s)\]」]*)?")
+
+# follow-up エージェントが要求するツール（呼ばれないと完了扱いにしない）
+REQUIRED_TOOLS_FIRST = {"generate_pptx", "save_meeting_record"}
+REQUIRED_TOOLS_FOLLOWUP = {"get_customer_history", "generate_pptx", "save_meeting_record"}
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """アプリ起動時に logging と長寿命プラグインを初期化する.
+
+    NOTE: agent と tracker はリクエスト毎に build する（tracker が state を
+    持つため共有不可）。CustomerHistoryPlugin は read-only なので使い回し OK。
+    """
+    setup_logging(settings.app_log_level)
+    logger.info("starting agent-first-meeting api...")
+    app.state.history_plugin = CustomerHistoryPlugin()
+    logger.info("history plugin initialized")
+    yield
+    logger.info("shutting down agent-first-meeting api")
+
+
+app = FastAPI(title="agent-first-meeting", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -36,17 +63,66 @@ def _sse(event: str, payload: dict) -> dict:
     return {"event": event, "data": json.dumps(payload, ensure_ascii=False)}
 
 
+def _check_followup_precondition(
+    history_plugin: CustomerHistoryPlugin, company_name: str
+) -> tuple[bool, str | None]:
+    """follow-up モードで前提となる過去面談があるか確認する.
+
+    Returns:
+        (ok, error_message). ok=False のとき error_message に理由が入る。
+    """
+    history_json = history_plugin.get_customer_history(company_name)
+    try:
+        history = json.loads(history_json)
+    except json.JSONDecodeError as e:
+        logger.exception("invalid history json: %s", e)
+        return False, "履歴の取得に失敗しました"
+    meetings = history.get("meetings") or []
+    if not meetings:
+        return False, (
+            f"「{company_name}」の過去面談が見つかりません。"
+            "「初回」を選択して初回面談を先に実施してください。"
+        )
+    return True, None
+
+
 @app.post("/api/first-meeting/generate")
 async def generate(req: GenerateRequest) -> EventSourceResponse:
     user_message = to_user_message(req)
+    logger.info(
+        "generate request: company=%s status=%s",
+        req.company_name, req.meeting_status,
+    )
 
     async def event_stream() -> AsyncGenerator[dict, None]:
-        agent = build_agent()
+        # meeting_status をトリガーにしてエージェントを分岐（リクエスト毎に build）
+        if req.meeting_status == "followup":
+            # 早期 return: 過去面談がなければ followup は意味をなさない
+            ok, reason = _check_followup_precondition(
+                app.state.history_plugin, req.company_name
+            )
+            if not ok:
+                logger.warning("followup precondition failed: %s", reason)
+                yield _sse(
+                    "done",
+                    {
+                        "status": "error",
+                        "data": None,
+                        "error": {"code": "NoPreviousMeeting", "message": reason},
+                    },
+                )
+                return
+            agent, tracker = build_followup_agent()
+            agent_label = "2回目以降"
+        else:
+            agent, tracker = build_agent()
+            agent_label = "初回"
+
         document_url: str | None = None
         accumulated_text = ""
 
         try:
-            yield _sse("thought", {"text": "エージェントを起動中..."})
+            yield _sse("thought", {"text": f"{agent_label}面談エージェントを起動中..."})
 
             async for chunk in agent.invoke_stream(messages=user_message):
                 message = chunk.message
@@ -61,8 +137,6 @@ async def generate(req: GenerateRequest) -> EventSourceResponse:
                         )
                     elif isinstance(item, FunctionResultContent):
                         result_str = str(item.result)
-                        if item.function_name and "generate_pptx" in item.function_name:
-                            document_url = result_str
                         yield _sse(
                             "tool_result",
                             {
@@ -76,23 +150,45 @@ async def generate(req: GenerateRequest) -> EventSourceResponse:
                             accumulated_text += text
                             yield _sse("message", {"text": text})
 
+            # Filter から確実に document_url / meeting_id / invoked_tools を取得
+            document_url = tracker.document_url
             if not document_url:
+                # フォールバック: テキストから正規表現で抽出
                 match = PPTX_URL_PATTERN.search(accumulated_text)
                 if match:
                     document_url = match.group(0)
 
+            warnings: list[str] = []
+            required = (
+                REQUIRED_TOOLS_FOLLOWUP
+                if req.meeting_status == "followup"
+                else REQUIRED_TOOLS_FIRST
+            )
+            missing = required - tracker.invoked_tools
+            if missing:
+                msg = f"必須ツールが呼ばれませんでした: {sorted(missing)}"
+                warnings.append(msg)
+                logger.warning(msg)
+
             yield _sse(
                 "done",
                 {
-                    "status": "success",
+                    "status": "success" if document_url else "error",
                     "data": {
                         "documentUrl": document_url,
                         "message": accumulated_text,
+                        "invokedTools": sorted(tracker.invoked_tools),
+                        "meetingId": tracker.meeting_id,
+                        "warnings": warnings,
                     },
-                    "error": None,
+                    "error": None if document_url else {
+                        "code": "NoDocument",
+                        "message": "PPTX が生成されませんでした",
+                    },
                 },
             )
         except Exception as e:  # noqa: BLE001
+            logger.exception("agent run failed")
             yield _sse(
                 "done",
                 {

--- a/agent-first-meeting/src/agent_first_meeting/logging_config.py
+++ b/agent-first-meeting/src/agent_first_meeting/logging_config.py
@@ -1,0 +1,26 @@
+"""アプリ全体の logging 初期化."""
+import logging
+import sys
+
+
+def setup_logging(level: str = "INFO") -> None:
+    """ルートロガーをアプリ標準の format で初期化する.
+
+    api.py の lifespan から一度だけ呼ばれる想定。
+    既に basicConfig 済みの場合は何もしない（pytest 等の二重初期化避け）。
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        # 既に何かしらの logger が立っているので二重初期化しない
+        return
+
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+    # ノイズの多いライブラリを抑制
+    logging.getLogger("azure").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/agent-first-meeting/src/agent_first_meeting/role_classifier.py
+++ b/agent-first-meeting/src/agent_first_meeting/role_classifier.py
@@ -1,0 +1,60 @@
+"""取引相手の役職を「経営層 / 部門責任者 / 担当者」の3カテゴリに分類する.
+
+UI は自由入力のため、辞書ベースのキーワードマッチで前処理する。
+辞書に無い場合は None を返し、LLM 側で判断させる契約。
+"""
+from typing import Literal
+
+PositionCategory = Literal["経営層", "部門責任者", "担当者"]
+
+# 重要：「部長」より先に「事業部長」を判定する必要があるため、
+#       より具体的なキーワードを先に並べる
+_KEYWORDS_BY_CATEGORY: list[tuple[str, PositionCategory]] = [
+    # 経営層
+    ("代表取締役", "経営層"),
+    ("CEO", "経営層"),
+    ("CTO", "経営層"),
+    ("CFO", "経営層"),
+    ("COO", "経営層"),
+    ("CIO", "経営層"),
+    ("CDO", "経営層"),
+    ("社長", "経営層"),
+    ("副社長", "経営層"),
+    ("会長", "経営層"),
+    ("常務", "経営層"),
+    ("専務", "経営層"),
+    ("執行役員", "経営層"),
+    ("取締役", "経営層"),
+    # 部門責任者
+    ("事業部長", "部門責任者"),
+    ("本部長", "部門責任者"),
+    ("副部長", "部門責任者"),
+    ("部長", "部門責任者"),
+    ("室長", "部門責任者"),
+    ("次長", "部門責任者"),
+    ("課長", "部門責任者"),
+    ("マネージャー", "部門責任者"),
+    ("マネジャー", "部門責任者"),
+    ("manager", "部門責任者"),
+    # 担当者
+    ("リーダー", "担当者"),
+    ("主任", "担当者"),
+    ("係長", "担当者"),
+    ("主査", "担当者"),
+    ("チーフ", "担当者"),
+    ("担当", "担当者"),
+    ("スタッフ", "担当者"),
+]
+
+
+def classify_position(position: str) -> PositionCategory | None:
+    """役職文字列を 3 カテゴリに分類. 不明な場合は None を返す."""
+    if not position:
+        return None
+    normalized = position.strip().lower()
+    if not normalized:
+        return None
+    for keyword, category in _KEYWORDS_BY_CATEGORY:
+        if keyword.lower() in normalized:
+            return category
+    return None

--- a/agent-first-meeting/src/agent_first_meeting/schemas.py
+++ b/agent-first-meeting/src/agent_first_meeting/schemas.py
@@ -1,5 +1,11 @@
 """API のリクエスト/レスポンス スキーマ."""
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
+
+from agent_first_meeting.role_classifier import classify_position
+
+MeetingStatus = Literal["first", "followup"]
 
 
 class GenerateRequest(BaseModel):
@@ -13,14 +19,54 @@ class GenerateRequest(BaseModel):
     known_info: str = Field(default="", alias="knownInfo", description="既知の課題感など")
     salesperson: str = Field(default="", description="担当営業名")
 
+    # Phase 2 追加：顧客 HP と取引相手の詳細
+    homepage_url: str = Field(
+        default="",
+        alias="homepageUrl",
+        description="顧客企業の公式 HP URL。WebFetchPlugin で本文を取得して提案の根拠に使う。",
+    )
+    contact_name: str = Field(
+        default="",
+        alias="contactName",
+        description="取引相手の氏名（例: 山田太郎）",
+    )
+    contact_department: str = Field(
+        default="",
+        alias="contactDepartment",
+        description="取引相手の部署（例: 経営企画部）",
+    )
+    contact_position: str = Field(
+        default="",
+        alias="contactPosition",
+        description="取引相手の役職（例: 部長）",
+    )
+    meeting_status: MeetingStatus = Field(
+        default="first",
+        alias="meetingStatus",
+        description="面談ステータス。'first' = 初回、'followup' = 2回目以降。",
+    )
+
 
 def to_user_message(req: GenerateRequest) -> str:
     """ユーザー向けプロンプト形式に整形する."""
+    status_label = "初回面談" if req.meeting_status == "first" else "2回目以降の面談"
+    position_category = classify_position(req.contact_position)
+    position_category_text = (
+        f"{position_category}（バックエンド側で自動分類）"
+        if position_category
+        else "不明（役職表記から判定できなかったので、あなたが判断してください）"
+    )
     return (
-        "以下の顧客の初回面談に向けたアポ資料を作ってください。\n\n"
+        f"以下の顧客の{status_label}に向けたアポ資料を作ってください。\n\n"
         f"- 会社名：{req.company_name}\n"
         f"- 業種：{req.industry}\n"
         f"- 規模：{req.scale}\n"
+        f"- 公式 HP：{req.homepage_url or '（未記入）'}\n"
+        f"- 取引相手：{req.contact_name or '（未記入）'}"
+        f"（部署：{req.contact_department or '（未記入）'} / "
+        f"役職：{req.contact_position or '（未記入）'}）\n"
+        f"- 取引相手の役職カテゴリ：{position_category_text}\n"
         f"- 既知の課題：{req.known_info or '（未記入）'}\n"
         f"- 担当営業：{req.salesperson or '（未記入）'}\n"
+        f"- 面談ステータス：{status_label}\n"
     )

--- a/agent-first-meeting/src/agent_first_meeting/tools/_html_to_text.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/_html_to_text.py
@@ -1,0 +1,20 @@
+"""HTML → 本文テキストの軽量変換ユーティリティ（Azure / SK 非依存）.
+
+`web_fetch.py` の `WebFetchPlugin` から切り出し、ユニットテスト容易性のため
+独立ファイルにしてある。bs4 にのみ依存。
+"""
+from bs4 import BeautifulSoup
+
+
+def strip_html(html: str) -> str:
+    """HTML から script/style/nav/footer/header を捨てて、本文テキストを抽出する.
+
+    - 連続する空白行は 1 つに圧縮
+    - 行頭・行末の空白は trim
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript", "nav", "footer", "header"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines)

--- a/agent-first-meeting/src/agent_first_meeting/tools/_pptx_builder.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/_pptx_builder.py
@@ -1,0 +1,82 @@
+"""PPTX 組み立てロジック（Azure 非依存・ユニットテスト容易）.
+
+`document_gen.py` の Blob アップロード処理から分離し、
+ローカルだけで PPTX 生成が再現できるようにする。
+"""
+from io import BytesIO
+
+from pptx import Presentation
+
+# 固定スライドのテンプレート文言（Phase 3 ではダミー値）
+DEFAULT_PRODUCT_NAME = "テスト商品"
+DEFAULT_PRODUCT_PRICE_JPY = 10
+AGENDA_ITEMS = [
+    "1. ご挨拶",
+    "2. 業界トレンドとお客様の課題",
+    "3. ご担当者向けのご提案",
+    "4. 自社商品のご紹介",
+    "5. 費用について",
+]
+
+
+def _add_cover(prs: Presentation, title: str, subtitle: str) -> None:
+    slide = prs.slides.add_slide(prs.slide_layouts[0])  # Title Slide
+    slide.shapes.title.text = title
+    slide.placeholders[1].text = subtitle
+
+
+def _add_content_slide(prs: Presentation, title: str, body: str) -> None:
+    """Title + bullet body の標準スライドを追加."""
+    slide = prs.slides.add_slide(prs.slide_layouts[1])  # Title and Content
+    slide.shapes.title.text = title
+    # placeholder[1] は body プレースホルダ。複数行は自動で箇条書きになる
+    slide.placeholders[1].text = body
+
+
+def build_presentation_bytes(
+    cover_title: str,
+    cover_subtitle: str,
+    industry_body: str,
+    position_body: str,
+    product_name: str = DEFAULT_PRODUCT_NAME,
+    product_price_jpy: int = DEFAULT_PRODUCT_PRICE_JPY,
+) -> bytes:
+    """6 スライド構成の PPTX をメモリ上に生成して bytes で返す.
+
+    Azure に依存しない純粋関数。ローカルでユニットテスト可能。
+    """
+    prs = Presentation()
+
+    # 1. 表紙
+    _add_cover(prs, cover_title, cover_subtitle)
+
+    # 2. 目次
+    _add_content_slide(prs, "本日のアジェンダ", "\n".join(AGENDA_ITEMS))
+
+    # 3. 対業界向け
+    _add_content_slide(prs, "業界トレンドとお客様の課題", industry_body)
+
+    # 4. 役職向け
+    _add_content_slide(prs, "ご担当者向けのご提案", position_body)
+
+    # 5. 自社商品
+    _add_content_slide(
+        prs,
+        "自社商品のご紹介",
+        f"商品名：{product_name}\n本日はこちらの商品をご提案いたします。",
+    )
+
+    # 6. 費用
+    _add_content_slide(
+        prs,
+        "費用について",
+        (
+            f"商品「{product_name}」のご提供価格\n"
+            f"価格：{product_price_jpy:,} 円（税別）\n"
+            "※ 詳細条件は別途ご相談のうえ決定いたします。"
+        ),
+    )
+
+    buf = BytesIO()
+    prs.save(buf)
+    return buf.getvalue()

--- a/agent-first-meeting/src/agent_first_meeting/tools/_url_safety.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/_url_safety.py
@@ -1,0 +1,72 @@
+"""SSRF ガード: URL の宛先 IP が内部リソースを指していないかを検証する.
+
+Azure Container Apps / VM / App Service 上で稼働させると、内部 IP や
+インスタンスメタデータ（169.254.169.254）に到達できてしまうため、
+ユーザー入力やエージェント生成の URL はここで弾く必要がある。
+"""
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# 名前ベースでも弾くホスト（Azure / AWS / GCP のメタデータ）
+_BLOCKED_HOSTNAMES = {
+    "169.254.169.254",
+    "metadata.google.internal",
+    "metadata",
+    "localhost",
+    "ip6-localhost",
+}
+
+
+def is_safe_public_url(url: str) -> tuple[bool, str]:
+    """URL が安全な公開エンドポイントを指しているか判定する.
+
+    Returns:
+        (ok, reason). ok=False のときは reason に弾いた理由が入る。
+    """
+    if not isinstance(url, str) or not url:
+        return False, "empty url"
+
+    try:
+        parsed = urlparse(url)
+    except ValueError as e:
+        return False, f"invalid url: {e}"
+
+    if parsed.scheme not in ("http", "https"):
+        return False, f"unsupported scheme: {parsed.scheme!r}"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return False, "no hostname"
+
+    if hostname.lower() in _BLOCKED_HOSTNAMES:
+        return False, f"blocked hostname: {hostname}"
+
+    # DNS 解決して、すべての A/AAAA レコードが公開 IP であることを確認
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        return False, f"dns resolution failed: {e}"
+
+    seen_addrs: list[str] = []
+    for info in infos:
+        addr = info[4][0]
+        seen_addrs.append(addr)
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return False, f"invalid ip from dns: {addr}"
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return False, f"blocked internal ip {addr} for host {hostname}"
+
+    if not seen_addrs:
+        return False, f"no addresses resolved for {hostname}"
+
+    return True, "ok"

--- a/agent-first-meeting/src/agent_first_meeting/tools/document_gen.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/document_gen.py
@@ -1,16 +1,19 @@
-"""PowerPoint 生成プラグイン (python-pptx + Azure Blob)."""
+"""PowerPoint 生成プラグイン (python-pptx + Azure Blob).
+
+Phase 3: 表紙 / 目次 / 対業界向け / 役職向け / 自社商品 / 費用 の 6 スライド構成。
+PPTX 組み立て本体は `_pptx_builder.build_presentation_bytes` に分離。
+本ファイルは「Blob アップロードと SAS 発行」に専念する。
+"""
 import uuid
 from datetime import datetime, timedelta, timezone
-from io import BytesIO
 from typing import Annotated
 
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobClient, BlobSasPermissions, BlobServiceClient, generate_blob_sas
-from pptx import Presentation
 from semantic_kernel.functions import kernel_function
 
 from agent_first_meeting.config import settings
-
+from agent_first_meeting.tools._pptx_builder import build_presentation_bytes
 
 SAS_EXPIRY_HOURS = 24
 
@@ -28,7 +31,7 @@ def _make_blob_service_client() -> BlobServiceClient:
 
 
 class DocumentGenPlugin:
-    """表紙 1 枚の PowerPoint を生成し Blob にアップロードする SK プラグイン."""
+    """6 スライド構成の PowerPoint を生成し Blob にアップロードする SK プラグイン."""
 
     def __init__(self) -> None:
         self._blob_service = _make_blob_service_client()
@@ -58,30 +61,48 @@ class DocumentGenPlugin:
 
     @kernel_function(
         description=(
-            "表紙だけの初回提案資料 (PowerPoint) を生成し、"
+            "6 スライド構成の初回提案資料 (PowerPoint) を生成し、"
             "Azure Blob にアップロードしてダウンロード可能な URL を返す。"
+            "スライド構成は固定で「表紙 / 目次 / 業界向け / 役職向け / 自社商品 / 費用」。"
+            "自社商品と費用の中身は呼び出し側では指定不要（既定値あり）。"
         ),
     )
     def generate_pptx(
         self,
-        title: Annotated[
+        cover_title: Annotated[
             str,
             "表紙のメインタイトル。例: '製造業のDX：技能継承課題への AI ナレッジ活用ご提案'",
         ],
-        subtitle: Annotated[
+        cover_subtitle: Annotated[
             str,
-            "表紙のサブタイトル。例: '株式会社サンプル製作所 様向け / 2026年5月'",
-        ] = "",
+            "表紙のサブタイトル。例: '株式会社サンプル製作所 様向け / 2026年5月 / 担当: 佐々木'",
+        ],
+        industry_body: Annotated[
+            str,
+            (
+                "「業界トレンドとお客様の課題」スライドの本文。"
+                "顧客の業界に共通する潮流・課題感を 3〜5 行の箇条書きで。"
+                "改行ごとに 1 つの箇条書き項目になる。"
+            ),
+        ],
+        position_body: Annotated[
+            str,
+            (
+                "「ご担当者向けのご提案」スライドの本文。"
+                "取引相手の役職（経営層 / 部門責任者 / 担当者）に響く論点を 3〜5 行の箇条書きで。"
+                "改行ごとに 1 つの箇条書き項目になる。"
+            ),
+        ],
     ) -> Annotated[str, "生成された PowerPoint の Blob URL."]:
-        prs = Presentation()
-        slide = prs.slides.add_slide(prs.slide_layouts[0])
-        slide.shapes.title.text = title
-        slide.placeholders[1].text = subtitle
-
-        buf = BytesIO()
-        prs.save(buf)
+        pptx_bytes = build_presentation_bytes(
+            cover_title=cover_title,
+            cover_subtitle=cover_subtitle,
+            industry_body=industry_body,
+            position_body=position_body,
+            # product / cost は固定値（Phase 3 ではダミー）
+        )
 
         blob_name = f"proposals/{uuid.uuid4().hex}.pptx"
         blob_client = self._container.get_blob_client(blob_name)
-        blob_client.upload_blob(buf.getvalue(), overwrite=True)
+        blob_client.upload_blob(pptx_bytes, overwrite=True)
         return self._build_download_url(blob_client)

--- a/agent-first-meeting/src/agent_first_meeting/tools/meeting_record.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/meeting_record.py
@@ -1,12 +1,29 @@
-"""面談レコードを Cosmos DB meetings コンテナに保存するプラグイン."""
-import uuid
+"""面談レコードを Cosmos DB meetings コンテナに保存するプラグイン.
+
+並行制御:
+- companyId は会社名から決定的に導出（SHA1 先頭12文字）。
+  → 同じ会社名なら必ず同じ ID になるので「並行 upsert で別 ID」問題が起きない。
+- meeting の id は f"mtg_{company_id}_{round:04d}" で一意性が保証される。
+  並行 create で 409 が返ったら round を +1 してリトライする。
+"""
+import logging
 from datetime import datetime, timezone
 from typing import Annotated
 
 from azure.cosmos import CosmosClient
+from azure.cosmos.exceptions import CosmosResourceExistsError
 from semantic_kernel.functions import kernel_function
 
+from agent_first_meeting._company_id import deterministic_company_id
 from agent_first_meeting.config import settings
+
+logger = logging.getLogger(__name__)
+
+_MAX_ROUND_RETRY = 50
+
+
+def _meeting_doc_id(company_id: str, round_num: int) -> str:
+    return f"mtg_{company_id}_{round_num:04d}"
 
 
 class MeetingRecordPlugin:
@@ -21,31 +38,24 @@ class MeetingRecordPlugin:
         self._customers = db.get_container_client("customers")
         self._meetings = db.get_container_client("meetings")
 
-    def _resolve_company_id(self, company_name: str) -> str:
-        existing = list(
-            self._customers.query_items(
-                query="SELECT * FROM c WHERE c.companyName = @name",
-                parameters=[{"name": "@name", "value": company_name}],
-                enable_cross_partition_query=True,
-            )
-        )
-        if existing:
-            return existing[0]["companyId"]
-
-        new_id = f"cus_{uuid.uuid4().hex[:12]}"
+    def _ensure_customer(self, company_name: str) -> str:
+        """会社マスタを upsert（決定的 ID で衝突を防ぐ）."""
+        company_id = deterministic_company_id(company_name)
         now_iso = datetime.now(timezone.utc).isoformat()
+        # 既存があれば updatedAt だけ更新、無ければ新規作成（どちらも upsert）
         self._customers.upsert_item(
             {
-                "id": new_id,
-                "companyId": new_id,
-                "companyName": company_name,
+                "id": company_id,
+                "companyId": company_id,
+                "companyName": company_name.strip(),
                 "createdAt": now_iso,
                 "updatedAt": now_iso,
             }
         )
-        return new_id
+        return company_id
 
-    def _next_round(self, company_id: str) -> int:
+    def _estimate_initial_round(self, company_id: str) -> int:
+        """次の round 番号の初期推定値を返す。並行時は create_item の 409 でリトライされる."""
         rows = list(
             self._meetings.query_items(
                 query="SELECT VALUE COUNT(1) FROM c WHERE c.companyId = @id",
@@ -73,21 +83,40 @@ class MeetingRecordPlugin:
             "初回面談で確認すべきポイントや次回アクション項目のリスト",
         ],
     ) -> Annotated[str, "保存された meetings ドキュメントの ID"]:
-        company_id = self._resolve_company_id(company_name)
-        round_num = self._next_round(company_id)
+        company_id = self._ensure_customer(company_name)
         now_iso = datetime.now(timezone.utc).isoformat()
+        initial_round = self._estimate_initial_round(company_id)
 
-        record = {
-            "id": f"mtg_{uuid.uuid4().hex}",
-            "companyId": company_id,
-            "round": round_num,
-            "scheduledAt": now_iso,
-            "status": "scheduled",
-            "preMeetingDocumentUrl": document_url,
-            "proposedTitle": proposed_title,
-            "outcomes": None,
-            "nextActions": next_actions,
-            "createdAt": now_iso,
-        }
-        self._meetings.upsert_item(record)
-        return record["id"]
+        # round 番号を +1 しつつリトライ（並行 create で 409 が返ったら次の番号に進む）
+        for round_num in range(initial_round, initial_round + _MAX_ROUND_RETRY):
+            record = {
+                "id": _meeting_doc_id(company_id, round_num),
+                "companyId": company_id,
+                "round": round_num,
+                "scheduledAt": now_iso,
+                "status": "scheduled",
+                "preMeetingDocumentUrl": document_url,
+                "proposedTitle": proposed_title,
+                "outcomes": None,
+                "nextActions": next_actions,
+                "createdAt": now_iso,
+            }
+            try:
+                self._meetings.create_item(record)
+            except CosmosResourceExistsError:
+                logger.info(
+                    "MeetingRecordPlugin: round %d already exists for %s, retrying",
+                    round_num, company_id,
+                )
+                continue
+
+            logger.info(
+                "MeetingRecordPlugin: saved id=%s company_id=%s round=%d",
+                record["id"], company_id, round_num,
+            )
+            return record["id"]
+
+        raise RuntimeError(
+            f"failed to allocate meeting round number for {company_id} "
+            f"after {_MAX_ROUND_RETRY} attempts"
+        )

--- a/agent-first-meeting/src/agent_first_meeting/tools/web_fetch.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/web_fetch.py
@@ -1,0 +1,128 @@
+"""企業 HP など外部 URL を取得して本文テキスト化するプラグイン.
+
+SSRF 対策:
+- スキームは http/https のみ
+- DNS 解決後の IP が private/loopback/link-local 等なら拒否
+- リダイレクトは手動で追跡し、各ホップで再チェック
+"""
+import json
+import logging
+from typing import Annotated
+
+import httpx
+from semantic_kernel.functions import kernel_function
+
+from agent_first_meeting.tools._html_to_text import strip_html
+from agent_first_meeting.tools._url_safety import is_safe_public_url
+
+logger = logging.getLogger(__name__)
+
+# 安全のためのリミット
+_FETCH_TIMEOUT_SEC = 10.0
+_MAX_BYTES = 1_000_000          # 1MB 上限（巨大ページの暴発を防ぐ）
+_MAX_TEXT_CHARS = 4_000         # LLM に投げるテキストの上限
+_MAX_REDIRECTS = 5              # リダイレクト追跡の上限
+_USER_AGENT = (
+    "Mozilla/5.0 (compatible; agent-first-meeting/0.1; +https://example.com/bot)"
+)
+
+
+def _error_payload(reason: str) -> str:
+    """LLM が構造的に判定できる JSON エラーを返す."""
+    return json.dumps({"ok": False, "error": reason}, ensure_ascii=False)
+
+
+def _ok_payload(text: str, final_url: str) -> str:
+    """LLM が構造的に判定できる JSON 成功レスポンスを返す."""
+    return json.dumps(
+        {"ok": True, "final_url": final_url, "text": text},
+        ensure_ascii=False,
+    )
+
+
+def _fetch_with_safe_redirects(client: httpx.Client, start_url: str) -> httpx.Response:
+    """SSRF 対策のため、リダイレクトを手動で追跡しつつ毎ホップで URL を検証する."""
+    current_url = start_url
+    for _ in range(_MAX_REDIRECTS):
+        ok, reason = is_safe_public_url(current_url)
+        if not ok:
+            raise PermissionError(f"refused unsafe url '{current_url}': {reason}")
+        resp = client.get(current_url)
+        if resp.status_code in (301, 302, 303, 307, 308):
+            next_url = resp.headers.get("location")
+            if not next_url:
+                raise httpx.HTTPError("redirect without Location header")
+            # 相対 URL の場合は前回 URL からの絶対化
+            current_url = str(httpx.URL(current_url).join(next_url))
+            continue
+        return resp
+    raise httpx.HTTPError(f"too many redirects (>{_MAX_REDIRECTS})")
+
+
+class WebFetchPlugin:
+    """顧客企業の HP など、外部 URL の本文テキストを取得する SK プラグイン."""
+
+    @kernel_function(
+        description=(
+            "顧客企業のホームページなど、外部 URL の本文テキストを取得する。"
+            "SSRF 対策のため内部 IP・メタデータエンドポイントは弾かれる。"
+            "返り値は JSON 文字列で {ok: bool, ...}。"
+            "  - 成功: {ok: true, final_url: '...', text: '...'}"
+            "  - 失敗: {ok: false, error: '...'}"
+            "失敗時はテキストとして利用してはならない。"
+        ),
+    )
+    def fetch_url_text(
+        self,
+        url: Annotated[
+            str,
+            "取得したい URL。http または https で始まる絶対 URL であること。",
+        ],
+    ) -> Annotated[str, "JSON 文字列。詳細は description を参照。"]:
+        logger.info("WebFetchPlugin: fetching url=%s", url)
+
+        ok, reason = is_safe_public_url(url)
+        if not ok:
+            logger.warning("WebFetchPlugin: refused url=%s reason=%s", url, reason)
+            return _error_payload(reason)
+
+        try:
+            with httpx.Client(
+                timeout=_FETCH_TIMEOUT_SEC,
+                follow_redirects=False,
+                headers={"User-Agent": _USER_AGENT},
+            ) as client:
+                resp = _fetch_with_safe_redirects(client, url)
+        except PermissionError as e:
+            logger.warning("WebFetchPlugin: blocked redirect: %s", e)
+            return _error_payload(str(e))
+        except httpx.HTTPError as e:
+            logger.warning(
+                "WebFetchPlugin: fetch error url=%s err=%s",
+                url, e, exc_info=True,
+            )
+            return _error_payload(f"fetch failed: {type(e).__name__}: {e}")
+
+        if resp.status_code >= 400:
+            logger.warning(
+                "WebFetchPlugin: http %s for %s", resp.status_code, url,
+            )
+            return _error_payload(f"http {resp.status_code}")
+
+        body_bytes = resp.content[:_MAX_BYTES]
+        try:
+            html = body_bytes.decode(resp.encoding or "utf-8", errors="replace")
+        except LookupError:
+            html = body_bytes.decode("utf-8", errors="replace")
+
+        text = strip_html(html)
+        if len(text) > _MAX_TEXT_CHARS:
+            text = text[:_MAX_TEXT_CHARS] + "\n...[truncated]"
+        if not text:
+            return _error_payload("empty body")
+
+        logger.info(
+            "WebFetchPlugin: success url=%s final=%s chars=%d",
+            url, resp.url, len(text),
+        )
+        return _ok_payload(text, str(resp.url))

--- a/agent-first-meeting/tests/test_html_to_text.py
+++ b/agent-first-meeting/tests/test_html_to_text.py
@@ -1,0 +1,92 @@
+"""`_html_to_text.strip_html` のテスト.
+
+bs4 だけに依存。WebFetchPlugin 本体（httpx 経由）は実 HTTP が必要なのでここでは扱わない。
+"""
+from agent_first_meeting.tools._html_to_text import strip_html
+
+
+def test_strips_script_and_style_tags():
+    """script / style の中身は出力に含まれないこと."""
+    html = """
+    <html><head>
+      <style>body { color: red; }</style>
+      <script>alert('xss');</script>
+    </head><body>
+      <p>こんにちは</p>
+    </body></html>
+    """
+    out = strip_html(html)
+    assert "こんにちは" in out
+    assert "color: red" not in out
+    assert "alert" not in out
+
+
+def test_strips_navigation_chrome():
+    """nav / footer / header は本文から除外されること."""
+    html = """
+    <html><body>
+      <header>サイトヘッダー（除外対象）</header>
+      <nav>メニュー（除外対象）</nav>
+      <main><p>本文コンテンツ</p></main>
+      <footer>フッター（除外対象）</footer>
+    </body></html>
+    """
+    out = strip_html(html)
+    assert "本文コンテンツ" in out
+    assert "サイトヘッダー" not in out
+    assert "メニュー" not in out
+    assert "フッター" not in out
+
+
+def test_compresses_blank_lines():
+    """連続する空白行が圧縮され、空行のないテキストが返ること."""
+    html = """
+    <html><body>
+      <p>段落1</p>
+
+
+      <p>段落2</p>
+
+
+
+
+      <p>段落3</p>
+    </body></html>
+    """
+    out = strip_html(html)
+    lines = out.splitlines()
+    # 空行が含まれない
+    assert all(line.strip() for line in lines)
+    # 3 行（段落 3 つ）
+    assert lines == ["段落1", "段落2", "段落3"]
+
+
+def test_handles_empty_body():
+    """空 HTML でも例外を投げないこと."""
+    assert strip_html("") == ""
+    assert strip_html("<html><body></body></html>") == ""
+
+
+def test_returns_japanese_business_content():
+    """企業 HP を想定した実用的な HTML を本文化できること."""
+    html = """
+    <html><head><title>会社案内</title></head>
+    <body>
+      <header>ロゴ・ナビ</header>
+      <main>
+        <h1>事業紹介</h1>
+        <p>当社は製造業向けのDXソリューションを提供しています。</p>
+        <ul>
+          <li>AI ナレッジ管理</li>
+          <li>技能継承支援</li>
+        </ul>
+      </main>
+      <footer>copyright 2026</footer>
+    </body></html>
+    """
+    out = strip_html(html)
+    assert "事業紹介" in out
+    assert "製造業向けのDXソリューション" in out
+    assert "AI ナレッジ管理" in out
+    assert "技能継承支援" in out
+    assert "copyright" not in out  # footer は除外

--- a/agent-first-meeting/tests/test_meeting_id.py
+++ b/agent-first-meeting/tests/test_meeting_id.py
@@ -1,0 +1,49 @@
+"""`_company_id.deterministic_company_id` / `meeting_record._meeting_doc_id` のテスト.
+
+`_company_id` は azure 系を import しないので直接 import 可能。
+`_meeting_doc_id` は meeting_record.py 内にあり azure-cosmos に依存するため、
+重い import を避けるためにここでは companyId の決定性のみを検証する。
+"""
+import pytest
+
+from agent_first_meeting._company_id import deterministic_company_id
+
+
+def test_company_id_is_deterministic():
+    """同じ会社名なら同じ companyId が出ること."""
+    a = deterministic_company_id("株式会社サンプル製作所")
+    b = deterministic_company_id("株式会社サンプル製作所")
+    assert a == b
+
+
+def test_company_id_normalizes_whitespace():
+    """前後の空白は無視して同じ ID になること."""
+    a = deterministic_company_id("株式会社サンプル")
+    b = deterministic_company_id("  株式会社サンプル  ")
+    assert a == b
+
+
+def test_company_id_is_unique_per_name():
+    """別の会社名なら別の ID が出ること."""
+    a = deterministic_company_id("株式会社A")
+    b = deterministic_company_id("株式会社B")
+    assert a != b
+
+
+def test_company_id_has_expected_prefix_and_length():
+    """`cus_` プレフィックス + 12 文字の hex で合計 16 文字."""
+    cid = deterministic_company_id("株式会社サンプル")
+    assert cid.startswith("cus_")
+    assert len(cid) == len("cus_") + 12
+    # SHA1 hex 部分は 0-9a-f
+    hex_part = cid[len("cus_"):]
+    assert all(c in "0123456789abcdef" for c in hex_part)
+
+
+@pytest.mark.parametrize("name", ["", "   "])
+def test_company_id_with_empty_name_is_still_deterministic(name):
+    """空文字でも例外を投げず、決定的に同じ ID を返すこと（保険）."""
+    a = deterministic_company_id(name)
+    b = deterministic_company_id(name)
+    assert a == b
+    assert a.startswith("cus_")

--- a/agent-first-meeting/tests/test_pptx_builder.py
+++ b/agent-first-meeting/tests/test_pptx_builder.py
@@ -1,0 +1,125 @@
+"""`_pptx_builder.build_presentation_bytes` の構造テスト.
+
+Azure / Semantic Kernel に依存せず、python-pptx だけでローカル実行可能。
+"""
+from io import BytesIO
+
+from pptx import Presentation
+
+from agent_first_meeting.tools._pptx_builder import (
+    AGENDA_ITEMS,
+    DEFAULT_PRODUCT_NAME,
+    DEFAULT_PRODUCT_PRICE_JPY,
+    build_presentation_bytes,
+)
+
+# 全テストで使う最小ペイロード
+SAMPLE_KWARGS = dict(
+    cover_title="製造業のDX：技能継承課題への AI ナレッジ活用ご提案",
+    cover_subtitle="株式会社サンプル製作所 様向け / 2026年5月 / 担当: 佐々木",
+    industry_body="ベテラン技術者の高齢化\n暗黙知の継承困難\n人手不足",
+    position_body="経営層: 人材リスクの定量化\n部門責任者: KPI 影響\n担当者: 現場 UI",
+)
+
+
+def _open_generated() -> Presentation:
+    data = build_presentation_bytes(**SAMPLE_KWARGS)
+    assert isinstance(data, bytes)
+    assert len(data) > 5_000, "PPTX が小さすぎる（破損？）"
+    return Presentation(BytesIO(data))
+
+
+def test_six_slides_are_generated():
+    """スライド枚数が固定の 6 枚であること."""
+    prs = _open_generated()
+    assert len(prs.slides) == 6
+
+
+def test_slide_titles_are_in_expected_order():
+    """各スライドのタイトル順が想定どおりであること."""
+    prs = _open_generated()
+    titles = [slide.shapes.title.text for slide in prs.slides]
+    assert titles == [
+        SAMPLE_KWARGS["cover_title"],
+        "本日のアジェンダ",
+        "業界トレンドとお客様の課題",
+        "ご担当者向けのご提案",
+        "自社商品のご紹介",
+        "費用について",
+    ]
+
+
+def test_cover_subtitle_is_rendered():
+    """表紙のサブタイトルが配置されていること."""
+    prs = _open_generated()
+    cover = prs.slides[0]
+    # placeholder[1] = サブタイトル
+    assert cover.placeholders[1].text == SAMPLE_KWARGS["cover_subtitle"]
+
+
+def test_industry_body_is_split_into_bullets():
+    """業界スライドの本文が改行で箇条書きに分割されていること."""
+    prs = _open_generated()
+    industry_slide = prs.slides[2]
+    body_text = industry_slide.placeholders[1].text
+    assert "ベテラン技術者の高齢化" in body_text
+    assert "暗黙知の継承困難" in body_text
+    assert "人手不足" in body_text
+    # 改行が保持されている（= 箇条書きとして展開されている）
+    lines = body_text.splitlines()
+    assert len(lines) >= 3
+
+
+def test_position_body_renders_role_specific_points():
+    """役職向けスライドが取引相手の役職別論点を含むこと."""
+    prs = _open_generated()
+    position_slide = prs.slides[3]
+    body_text = position_slide.placeholders[1].text
+    assert "経営層" in body_text
+    assert "部門責任者" in body_text
+    assert "担当者" in body_text
+
+
+def test_product_slide_uses_default_product_name():
+    """自社商品スライドに既定の商品名（テスト商品）が入ること."""
+    prs = _open_generated()
+    product_slide = prs.slides[4]
+    body_text = product_slide.placeholders[1].text
+    assert DEFAULT_PRODUCT_NAME in body_text
+    assert DEFAULT_PRODUCT_NAME == "テスト商品"
+
+
+def test_cost_slide_includes_default_price():
+    """費用スライドに既定価格（10 円）が入ること."""
+    prs = _open_generated()
+    cost_slide = prs.slides[5]
+    body_text = cost_slide.placeholders[1].text
+    assert DEFAULT_PRODUCT_PRICE_JPY == 10
+    assert "10" in body_text
+    assert "円" in body_text
+    assert DEFAULT_PRODUCT_NAME in body_text
+
+
+def test_product_price_can_be_overridden():
+    """既定値を上書きできること（将来の本実装に向けた契約テスト）."""
+    data = build_presentation_bytes(
+        **SAMPLE_KWARGS,
+        product_name="プレミアム商品",
+        product_price_jpy=120_000,
+    )
+    prs = Presentation(BytesIO(data))
+    cost_body = prs.slides[5].placeholders[1].text
+    product_body = prs.slides[4].placeholders[1].text
+    assert "プレミアム商品" in cost_body
+    assert "プレミアム商品" in product_body
+    # 桁区切りで表示される
+    assert "120,000" in cost_body
+
+
+def test_agenda_items_are_rendered_in_table_of_contents():
+    """目次スライドが AGENDA_ITEMS をすべて含むこと."""
+    prs = _open_generated()
+    toc_slide = prs.slides[1]
+    toc_text = toc_slide.placeholders[1].text
+    for item in AGENDA_ITEMS:
+        assert item in toc_text

--- a/agent-first-meeting/tests/test_role_classifier.py
+++ b/agent-first-meeting/tests/test_role_classifier.py
@@ -1,0 +1,47 @@
+"""役職カテゴリ分類のテスト."""
+import pytest
+
+from agent_first_meeting.role_classifier import classify_position
+
+
+@pytest.mark.parametrize(
+    "position,expected",
+    [
+        # 経営層
+        ("代表取締役社長", "経営層"),
+        ("CEO", "経営層"),
+        ("ceo", "経営層"),
+        ("CFO", "経営層"),
+        ("取締役", "経営層"),
+        ("常務取締役", "経営層"),
+        ("執行役員", "経営層"),
+        # 部門責任者（事業部長が部長より優先されること）
+        ("事業部長", "部門責任者"),
+        ("営業本部長", "部門責任者"),
+        ("経営企画部長", "部門責任者"),
+        ("課長", "部門責任者"),
+        ("マネージャー", "部門責任者"),
+        ("Senior Manager", "部門責任者"),
+        # 担当者
+        ("主任", "担当者"),
+        ("係長", "担当者"),
+        ("チームリーダー", "担当者"),
+        ("担当", "担当者"),
+    ],
+)
+def test_known_positions_are_classified(position, expected):
+    assert classify_position(position) == expected
+
+
+@pytest.mark.parametrize("empty", ["", "   ", None])
+def test_empty_input_returns_none(empty):
+    assert classify_position(empty) is None
+
+
+@pytest.mark.parametrize(
+    "unknown",
+    ["相談役", "アンバサダー", "メンター", "顧問"],
+)
+def test_unknown_positions_return_none(unknown):
+    # 辞書に無い役職は None（= LLM 判定にゆだねる）
+    assert classify_position(unknown) is None

--- a/agent-first-meeting/tests/test_schemas.py
+++ b/agent-first-meeting/tests/test_schemas.py
@@ -1,0 +1,100 @@
+"""`schemas.GenerateRequest` のバリデーションと `to_user_message` 整形のテスト."""
+import pytest
+from pydantic import ValidationError
+
+from agent_first_meeting.schemas import GenerateRequest, to_user_message
+
+
+def _minimum_payload(**overrides) -> dict:
+    base = {
+        "companyName": "株式会社サンプル",
+        "industry": "製造業",
+        "scale": "中小企業",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_minimum_required_fields_are_accepted():
+    """3 つの必須項目だけでバリデーションが通り、任意項目はデフォルトになること."""
+    req = GenerateRequest(**_minimum_payload())
+    assert req.company_name == "株式会社サンプル"
+    assert req.industry == "製造業"
+    assert req.scale == "中小企業"
+    assert req.known_info == ""
+    assert req.salesperson == ""
+    assert req.homepage_url == ""
+    assert req.contact_name == ""
+    assert req.contact_department == ""
+    assert req.contact_position == ""
+    assert req.meeting_status == "first"
+
+
+def test_missing_required_company_name_raises():
+    """会社名が無いとバリデーションエラーになること."""
+    with pytest.raises(ValidationError):
+        GenerateRequest(industry="製造業", scale="中小企業")
+
+
+def test_camel_case_aliases_are_accepted():
+    """フロントエンドが投げる camelCase キーで受けられること."""
+    req = GenerateRequest(
+        **_minimum_payload(
+            homepageUrl="https://example.co.jp",
+            contactName="山田太郎",
+            contactDepartment="経営企画部",
+            contactPosition="部長",
+            meetingStatus="followup",
+        )
+    )
+    assert req.homepage_url == "https://example.co.jp"
+    assert req.contact_name == "山田太郎"
+    assert req.contact_department == "経営企画部"
+    assert req.contact_position == "部長"
+    assert req.meeting_status == "followup"
+
+
+def test_meeting_status_literal_rejects_invalid_value():
+    """meeting_status は 'first' / 'followup' 以外は拒否されること."""
+    with pytest.raises(ValidationError):
+        GenerateRequest(**_minimum_payload(meetingStatus="third"))
+
+
+def test_to_user_message_includes_all_fields():
+    """整形済みプロンプトに全 5 項目（HP / 氏名 / 部署 / 役職 / ステータス）が含まれること."""
+    req = GenerateRequest(
+        **_minimum_payload(
+            homepageUrl="https://example.co.jp",
+            contactName="山田太郎",
+            contactDepartment="経営企画部",
+            contactPosition="部長",
+            meetingStatus="followup",
+            knownInfo="DX 推進中",
+            salesperson="佐々木",
+        )
+    )
+    msg = to_user_message(req)
+    assert "株式会社サンプル" in msg
+    assert "https://example.co.jp" in msg
+    assert "山田太郎" in msg
+    assert "経営企画部" in msg
+    assert "部長" in msg
+    assert "2回目以降の面談" in msg
+    assert "DX 推進中" in msg
+    assert "佐々木" in msg
+
+
+def test_to_user_message_first_meeting_label():
+    """meeting_status='first' のときは「初回面談」と表示されること."""
+    req = GenerateRequest(**_minimum_payload())
+    msg = to_user_message(req)
+    assert "初回面談" in msg
+    assert "2回目以降" not in msg
+
+
+def test_to_user_message_marks_missing_optional_fields():
+    """任意項目が空のとき「（未記入）」が出ること."""
+    req = GenerateRequest(**_minimum_payload())
+    msg = to_user_message(req)
+    # HP, 氏名, 部署, 役職, 既知の課題, 担当営業 はすべて未記入
+    assert "（未記入）" in msg

--- a/agent-first-meeting/tests/test_url_safety.py
+++ b/agent-first-meeting/tests/test_url_safety.py
@@ -1,0 +1,86 @@
+"""SSRF ガード `_url_safety.is_safe_public_url` のテスト."""
+from unittest.mock import patch
+
+import pytest
+
+from agent_first_meeting.tools._url_safety import is_safe_public_url
+
+
+def _mock_getaddrinfo(ip: str):
+    """socket.getaddrinfo の戻り値を ip 1つだけにモックするヘルパ."""
+    return [(0, 0, 0, "", (ip, 0))]
+
+
+def test_rejects_invalid_scheme():
+    ok, reason = is_safe_public_url("ftp://example.com")
+    assert ok is False
+    assert "scheme" in reason
+
+
+def test_rejects_empty_url():
+    ok, reason = is_safe_public_url("")
+    assert ok is False
+
+
+def test_rejects_url_without_hostname():
+    ok, reason = is_safe_public_url("http:///path")
+    assert ok is False
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    ["169.254.169.254", "metadata.google.internal", "localhost", "metadata"],
+)
+def test_rejects_known_metadata_hostnames(hostname):
+    ok, reason = is_safe_public_url(f"http://{hostname}/foo")
+    assert ok is False
+    assert "blocked" in reason.lower() or "internal" in reason.lower()
+
+
+@pytest.mark.parametrize(
+    "internal_ip",
+    [
+        "127.0.0.1",         # loopback
+        "10.0.0.5",          # private
+        "192.168.1.1",       # private
+        "172.16.0.1",        # private
+        "169.254.169.254",   # link-local / IMDS
+        "0.0.0.0",           # unspecified
+        "::1",               # ipv6 loopback
+        "fc00::1",           # ipv6 unique-local (private)
+    ],
+)
+def test_rejects_internal_ip_resolutions(internal_ip):
+    """DNS が内部 IP を返した場合に弾かれること."""
+    with patch(
+        "agent_first_meeting.tools._url_safety.socket.getaddrinfo",
+        return_value=_mock_getaddrinfo(internal_ip),
+    ):
+        ok, reason = is_safe_public_url("http://attacker.example.com/foo")
+    assert ok is False
+    # 名前ベースで弾いたか、IP ベースで弾いたか、いずれかのメッセージ
+    assert (
+        "internal" in reason.lower()
+        or "blocked" in reason.lower()
+    ), reason
+
+
+def test_accepts_public_ip_resolution():
+    """公開 IP が返れば通ること."""
+    with patch(
+        "agent_first_meeting.tools._url_safety.socket.getaddrinfo",
+        return_value=_mock_getaddrinfo("93.184.216.34"),  # example.com の旧 IP
+    ):
+        ok, reason = is_safe_public_url("https://example.com/")
+    assert ok is True, reason
+
+
+def test_dns_failure_is_treated_as_unsafe():
+    import socket as real_socket
+    with patch(
+        "agent_first_meeting.tools._url_safety.socket.getaddrinfo",
+        side_effect=real_socket.gaierror("simulated"),
+    ):
+        ok, reason = is_safe_public_url("http://does-not-exist.example.invalid/")
+    assert ok is False
+    assert "dns" in reason.lower()

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -46,12 +46,29 @@ with st.form("input_form"):
                 "その他",
             ],
         )
+        homepage_url = st.text_input(
+            "企業ホームページ URL（任意）",
+            placeholder="https://example.co.jp",
+        )
     with col2:
         scale = st.selectbox(
             "規模 *",
             ["大企業", "中堅企業", "中小企業", "スタートアップ"],
         )
         salesperson = st.text_input("担当営業（任意）")
+        meeting_status_label = st.selectbox(
+            "面談回数ステータス *",
+            ["初回", "2回目以降"],
+        )
+
+    st.markdown("**取引相手の情報（任意）**")
+    col3, col4, col5 = st.columns(3)
+    with col3:
+        contact_name = st.text_input("氏名", placeholder="山田 太郎")
+    with col4:
+        contact_department = st.text_input("部署", placeholder="経営企画部")
+    with col5:
+        contact_position = st.text_input("役職", placeholder="部長")
 
     known_info = st.text_area(
         "既知の課題感（任意）",
@@ -76,6 +93,11 @@ if submitted:
         "scale": scale,
         "knownInfo": known_info,
         "salesperson": salesperson,
+        "homepageUrl": homepage_url,
+        "contactName": contact_name,
+        "contactDepartment": contact_department,
+        "contactPosition": contact_position,
+        "meetingStatus": "first" if meeting_status_label == "初回" else "followup",
     }
 
     st.divider()
@@ -122,13 +144,22 @@ if submitted:
                         elif current_event == "message":
                             accumulated_text += data.get("text", "")
                         elif current_event == "done":
-                            if data.get("status") == "success":
-                                document_url = data.get("data", {}).get(
-                                    "documentUrl"
-                                )
-                                status.update(
-                                    label="生成完了 ✅", state="complete"
-                                )
+                            status_val = data.get("status")
+                            if status_val in ("success", "partial"):
+                                payload = data.get("data") or {}
+                                document_url = payload.get("documentUrl")
+                                warnings = payload.get("warnings") or []
+                                if status_val == "partial":
+                                    status.update(
+                                        label="生成完了（警告あり） ⚠️",
+                                        state="complete",
+                                    )
+                                else:
+                                    status.update(
+                                        label="生成完了 ✅", state="complete"
+                                    )
+                                for w in warnings:
+                                    st.warning(w)
                             else:
                                 err = data.get("error") or {}
                                 status.update(label="エラー", state="error")


### PR DESCRIPTION
## Summary
- **PPTX 6 スライド化**: 表紙 / 目次 / 業界向け / 役職向け / 自社商品（テスト商品） / 費用（10円）の固定構成。組み立てロジックを `_pptx_builder.py` に分離し Azure 非依存でユニットテスト可能に
- **UI 拡充**: 企業 HP URL / 取引相手の氏名・部署・役職 / 面談ステータスをフォームに追加。`WebFetchPlugin` 新規（SSRF ガード + リダイレクト追跡で安全に HP 本文を取得）
- **SK 1.42 互換性**: `invoke_stream` で `FunctionCallContent` が流れない仕様変更に対応するため、`ToolResultTracker` (`FunctionInvocationFilter`) で generate_pptx の Blob URL と save_meeting_record の meeting_id を確実に取得
- **ハードニング**: companyId を会社名から決定的に導出（SHA1）、round 採番は `create_item` 409 でリトライ、SSRF ガード（内部 IP / IMDS をブロック）、役職カテゴリ自動分類、logging 基盤、Cosmos/Foundry/Blob クライアントを lifespan で初期化
- **テスト**: pytest 68 件追加（Azure / SK 非依存で軽量に実行可能）
- **ドキュメント**: README に Mermaid 図（システム構成 / シーケンス / 判断ロジック）追加

## Test plan
- [x] `pytest tests/ -v` 全 68 件 PASS（test_pptx_builder / test_schemas / test_html_to_text / test_url_safety / test_role_classifier / test_meeting_id）
- [x] Foundry (GPT-4.1) 接続スモークテスト OK
- [x] Streamlit + FastAPI を起動して新規顧客シナリオで end-to-end 動作確認 — エージェントが `get_customer_history` → `fetch_url_text` → `search_similar_cases` → `generate_pptx` → `save_meeting_record` の順で全ツール呼び出し成功
- [x] Cosmos に決定的 ID で companyId が再利用され、round が自動採番（round=1 → round=2）で保存
- [x] Blob に SAS 付き URL（24h）で 6 スライド PPTX がアップロード
- [x] `ToolResultTracker` のログで `captured document_url len=214` `captured meeting_id=mtg_cus_xxx` を確認
- [ ] レビュー後 develop に squash merge

## 動作確認で発見・修正したバグ
- Python 3.12 x64 を python.org から導入（ARM64 Windows + Python 3.14 では SK 1.42 の型ヒント解析が壊れるため）
- Phase 4 の必須ツール検証ロジックが SK 1.42 で機能しない問題を `ToolResultTracker` で解決
- `frontend/main.py` が `partial` ステータス未対応だった点を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)