### PR TITLE
docs: Azure CLI セットアップ手順を実体験ベースに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,42 +212,74 @@ gitGraph
 
 ### 前提条件
 
-- Python 3.11 以上
-- Docker / Docker Compose
+- **Python 3.12** 動作確認済み（3.11 以上であれば動く想定）
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`) v2.60+ ＋ 有効な Azure サブスクリプション
+- （統合フェーズで使用）Docker / Docker Compose
 
 ### セットアップ手順
 
-```bash
-# 1. 環境変数を設定（仮）
-cp .env.example .env
-# .env を開いてAPIキー等を入力
- 
-# 2. 各エージェントの仮想環境を作成・依存インストール
+```powershell
+# 1. Azure リソースを Azure CLI で一括構築
+#    詳細は agent-first-meeting/docs/azure_setup.md を参照
+az login
+# ↑ ガイドの「0. 準備」→「4. Blob Storage」までを順にコピペ実行
+#   Foundry / Cosmos DB（vector search 込み）/ Blob Storage が立ち上がる
+
+# 2. .env を作成（ガイドの「5. .env への反映」で値を流し込む）
+cp agent-first-meeting/.env.example agent-first-meeting/.env
+# Azure CLI で取得した値をエディタで貼り付け
+
+# 3. agent-first-meeting の仮想環境＋依存インストール
 cd agent-first-meeting
 python -m venv .venv
-source .venv/bin/activate   
+.\.venv\Scripts\Activate.ps1     # macOS/Linux: source .venv/bin/activate
 pip install -e ".[dev]"
-cd ..
- 
-cd agent-follow-up
+
+# 4. Azure リソースへのスモークテスト＆シードデータ投入
+python scripts/check_foundry.py        # Foundry 疎通
+python scripts/seed_cases.py           # cases コンテナへ投入
+python scripts/seed_customer.py        # customers / meetings へ投入
+python scripts/check_vector_search.py  # vector 検索の動作確認
+python scripts/check_pptx_blob.py      # Blob アップロードの動作確認
+
+# 5. API サーバー起動
+python scripts/run_server.py           # http://127.0.0.1:8000
+
+# 6. 別ターミナルで Streamlit フロントエンドを起動
+cd ../frontend
 python -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
-cd ..
- 
-# 4. Dockerで全体起動（統合時）
-docker-compose up --build
+.\.venv\Scripts\Activate.ps1
+pip install -e .
+streamlit run main.py                  # http://localhost:8501
 ```
 
+> 📘 Azure リソースの作成（`az group create` から `az role assignment create` まで）は **[agent-first-meeting/docs/azure_setup.md](agent-first-meeting/docs/azure_setup.md)** にコピペ可能な PowerShell コマンドで一式まとめてあります。
+
 ### 環境変数一覧
- 
+
+`.env` の全項目とその取得方法は [agent-first-meeting/docs/azure_setup.md §5](agent-first-meeting/docs/azure_setup.md#5-env-への反映) を参照。主なキーは以下：
+
 | 変数名 | 説明 | 必須 |
 |---|---|---|
-| `***_API_KEY` | Model APIキー | ✅ |
-| `FIRST_MEETING_API_URL` | 初回エージェントのURL | ✅ |
-| `FOLLOW_UP_API_URL` | フォローアップエージェントのURL | ✅ |
- 
+| `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_API_KEY` | Foundry (Azure OpenAI) | ✅ |
+| `AZURE_OPENAI_CHAT_DEPLOYMENT` | チャットモデルのデプロイ名（推奨 `gpt-4o`。`gpt-4.1` のクオータがあれば可） | ✅ |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | 埋め込みモデルのデプロイ名（既定 `text-embedding-3-large`） | ✅ |
+| `COSMOS_ENDPOINT` / `COSMOS_KEY` | Cosmos DB 接続情報 | ✅ |
+| `COSMOS_DATABASE` | データベース名（既定 `sales-agent`） | ✅ |
+| `BLOB_ACCOUNT_URL` / `BLOB_CONTAINER` | 生成 pptx の保存先 | ✅ |
+| `BLOB_ACCOUNT_KEY` | SAS 付きダウンロード URL を発行したい場合のみ | 任意 |
+| `FIRST_MEETING_API_URL` | フロントエンドが叩く API URL（既定 `http://127.0.0.1:8000/api/first-meeting/generate`） | 任意 |
+
 > ⚠️ `.env` は絶対にGitにコミットしないでください。`.env.example`（ダミー値入り）のみをGitで管理します。
+
+### 後片付け
+
+ハッカソン終了後はリソースグループごと削除すれば課金が止まります：
+
+```powershell
+# azure_setup.md §0-3 で定義した $RG をそのまま使う
+az group delete --name $RG --yes --no-wait
+```
  
 ---
  

--- a/agent-first-meeting/docs/azure_setup.md
+++ b/agent-first-meeting/docs/azure_setup.md
@@ -1,19 +1,21 @@
-# Azure リソース セットアップ手順
+# Azure リソース セットアップ手順（Azure CLI 版）
 
-`agent-first-meeting` を動かすために必要な Azure リソースを、Azure Portal の GUI で作成する手順です。
+`agent-first-meeting` を動かすために必要な Azure リソースを **Azure CLI** で作成する手順です。
 
 個人アカウント＋$200 無料クレジット前提で、最小コストになる選択肢で記載しています。
+コマンドは Windows **PowerShell** 用に書いていますが、macOS/Linux の bash でも変数定義の構文を `VAR=value` / `$VAR` に置き換えるだけで同じように動きます。
 
 ## 目次
 
 - [前提](#前提)
 - [作成順序とリージョン方針](#作成順序とリージョン方針)
+- [0. 準備（CLI セットアップと共通変数）](#0-準備cli-セットアップと共通変数)
 - [1. リソースグループ](#1-リソースグループ)
-- [2. Azure AI Foundry](#2-azure-ai-foundry)
+- [2. Azure AI Foundry（Azure OpenAI）](#2-azure-ai-foundryazure-openai)
 - [3. Azure Cosmos DB for NoSQL](#3-azure-cosmos-db-for-nosql)
 - [4. Azure Blob Storage](#4-azure-blob-storage)
 - [5. .env への反映](#5-env-への反映)
-- [6. Container Apps（後回し）](#6-container-apps後回し)
+- [6. 後片付け（リソース削除）](#6-後片付けリソース削除)
 - [概算コスト](#概算コスト)
 - [つまずきポイント](#つまずきポイント)
 
@@ -21,268 +23,468 @@
 
 ## 前提
 
-- [ ] [Azure Portal](https://portal.azure.com) にサインインできる
-- [ ] サブスクリプションが「無料試用版」または個人契約で有効
+- [ ] Azure サブスクリプションが「無料試用版」または個人契約で有効
+- [ ] [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`) がインストール済み（`az --version` で 2.60 以上を推奨）
 - [ ] [agent-first-meeting/.env.example](../.env.example) をコピーして `.env` を準備済み（最後に値を埋める）
 
 ---
 
 ## 作成順序とリージョン方針
 
-後の手順で前のリソース情報が必要になるため、上から順に作成してください。
-
 | 順 | リソース | 用途 |
 |---|---|---|
 | 1 | リソースグループ | 全リソースの入れ物 |
-| 2 | Azure AI Foundry（Hub + Project + モデル） | GPT-4.1 / text-embedding-3-large |
+| 2 | Azure OpenAI（Foundry のベース）＋ GPT-4.1 / text-embedding-3-large デプロイ | LLM・埋め込み |
 | 3 | Cosmos DB for NoSQL | 顧客・面談・事例（vector search 込み） |
 | 4 | Blob Storage | 生成 PowerPoint の保存先 |
 
 ### リージョン
 
-**全リソースを `East US 2` で揃える** ことを推奨します。
+**全リソースを `eastus2` で揃える** ことを推奨します。
 
-- Foundry の Anthropic Claude モデルは East US 2 / West US 3 で配信されることが多く、リージョン依存
+- Foundry の GPT-4.1 / text-embedding-3-large は East US 2 で配信されていることが多い
 - 同一リージョンに揃えると **リソース間通信が無料 ＆ レイテンシ最小**
+
+---
+
+## 0. 準備（CLI セットアップと共通変数）
+
+### 0-1. ログインとサブスクリプション確認
+
+```powershell
+az login
+az account show --query "{name:name, id:id, user:user.name}" -o table
+```
+
+複数サブスクリプションがある場合は明示的に切り替え：
+
+```powershell
+az account set --subscription "<subscription-id-or-name>"
+```
+
+### 0-2. プロバイダー登録（初回のみ）
+
+```powershell
+az provider register --namespace Microsoft.CognitiveServices
+az provider register --namespace Microsoft.DocumentDB
+az provider register --namespace Microsoft.Storage
+
+# 登録完了確認（"Registered" になるまで待つ）
+"Microsoft.CognitiveServices","Microsoft.DocumentDB","Microsoft.Storage" | % {
+  "$_ : $(az provider show -n $_ --query registrationState -o tsv)"
+}
+```
+
+> ⏱️ **`Microsoft.Storage` は数分かかることがあります。** `Registering` 状態のまま次の Storage 作成に進むと `MissingSubscriptionRegistration` で落ちます。すべて `Registered` になってから先へ進んでください。
+
+### 0-3. モデル可用性とクオータの事前確認（重要）
+
+個人サブスクリプションでは特定モデルのクオータが **0** のことがあります。
+リソースを作る前に必ずチェックしてください。
+
+```powershell
+# eastus2 でリージョン提供されているモデル名・バージョンの一覧
+az cognitiveservices model list --location eastus2 `
+  --query "[?model.name=='gpt-4.1' || model.name=='gpt-4o' || model.name=='text-embedding-3-large'].{name:model.name, version:model.version}" `
+  -o table
+
+# このサブスクリプションに割り当てられているクオータ（limit > 0 のものだけ）
+az cognitiveservices usage list --location eastus2 -o json `
+  | ConvertFrom-Json `
+  | ? { $_.limit -gt 0 -and ($_.name.value -like "*gpt-4*" -or $_.name.value -like "*embedding-3-large*") } `
+  | % { "{0,-55} limit={1}" -f $_.name.value, $_.limit }
+```
+
+> 🛑 **本ガイドは当初 `gpt-4.1` を想定していますが、`OpenAI.GlobalStandard.gpt-4.1` の limit が 0 のサブスクリプションが多数あります。** その場合は §2-2 で `gpt-4o` を代わりにデプロイしてください（コードは `.env` でモデル名を抽象化しているため変更箇所は 1 行）。
+
+### 0-3. 共通変数（以降のコマンドで再利用）
+
+リソース名のうち `<unique>` 部分はグローバル一意である必要があるので、自分のイニシャル＋日付などで置き換えてください（例: `mb20260518`）。
+
+```powershell
+$LOCATION       = "eastus2"
+$RG             = "rg-sales-agent"
+
+$AOAI_NAME      = "aoai-sales-agent-<unique>"   # Azure OpenAI アカウント名
+$CHAT_DEPLOY    = "gpt-4o"                      # チャットデプロイ名（.env と一致させる）。クオータがあれば gpt-4.1 でも可
+$EMBED_DEPLOY   = "text-embedding-3-large"      # 埋め込みデプロイ名（.env と一致させる）
+
+$COSMOS_NAME    = "cosmos-sales-agent-<unique>" # Cosmos DB アカウント名
+$COSMOS_DB      = "sales-agent"                 # データベース名
+
+$STORAGE_NAME   = "stsalesagent<unique>"        # Storage アカウント名（小文字英数のみ・24文字以内）
+$BLOB_CONTAINER = "generated-documents"
+```
+
+> 💡 同じシェルセッションを閉じる前に最後まで通すか、`.ps1` スクリプトとして保存しておくと楽です。
 
 ---
 
 ## 1. リソースグループ
 
-ポータル → 「リソース グループ」→ **+ 作成**
-
-| 項目 | 値 |
-|---|---|
-| サブスクリプション | 個人のもの |
-| リソース グループ | `rg-sales-agent` |
-| リージョン | `East US 2` |
-
-→ 「確認及び作成」→ 作成
+```powershell
+az group create --name $RG --location $LOCATION
+```
 
 ---
 
-## 2. Azure AI Foundry
+## 2. Azure AI Foundry（Azure OpenAI）
 
-### 2-1. Foundry Hub と Project の作成
+Foundry プロジェクトの実体は Azure OpenAI リソースなので、CLI からは `cognitiveservices account` として作成します。
 
-[https://ai.azure.com](https://ai.azure.com) にアクセス → 「**+ 新しいプロジェクト**」
+### 2-1. Azure OpenAI アカウント作成
 
-| 項目 | 値 |
-|---|---|
-| Hub 名 | `hub-sales-agent` |
-| Project 名 | `proj-sales-agent` |
-| リソース グループ | `rg-sales-agent` |
-| リージョン | `East US 2` |
+```powershell
+az cognitiveservices account create `
+  --name $AOAI_NAME `
+  --resource-group $RG `
+  --location $LOCATION `
+  --kind OpenAI `
+  --sku S0 `
+  --custom-domain $AOAI_NAME `
+  --yes
+```
 
-> Hub 作成時に Storage Account / Key Vault / Application Insights が自動で一緒に作られます（Foundry の付帯リソース）。これらはそのまま残してOKです。
+> `--custom-domain` を付けると `https://<name>.openai.azure.com/` 形式の固定エンドポイントが発行され、`.env` の `AZURE_OPENAI_ENDPOINT` にそのまま入れられます。
 
-### 2-2. GPT-4.1 のデプロイ
+### 2-2. チャットモデルのデプロイ
 
-Project 画面 → 左メニュー「**モデル + エンドポイント**」→ 「**+ モデルのデプロイ**」→ 「**ベースモデル**」
+§0-3 で確認したクオータをもとに **デプロイするモデルを 1 つ選んでください**。
 
-| 項目 | 値 |
-|---|---|
-| モデル | `gpt-4.1`（Azure OpenAI 提供） |
-| デプロイ名 | **`gpt-4.1`**（`.env` の `AZURE_OPENAI_CHAT_DEPLOYMENT` と一致させる） |
-| デプロイの種類 | **Standard / Global Standard (PAYG)**（従量課金、アイドル時0円） |
-| コンテンツフィルター | 既定でOK |
+#### 推奨：`gpt-4o`（多くの個人サブスクで `GlobalStandard` が即使える）
 
-> 当初設計では Claude Sonnet 4.6 を使う予定だったが、個人 Azure サブスクリプションでは Anthropic モデルが全リージョン・全バリアントでクオータ 0（要申請）だったため、確実に動く GPT-4.1 を採用。コードはモデル名を `.env` で抽象化しているため、後日 Claude のクオータが通れば 1 行変更で差し替え可能。
->
-> GPT-4.1 もリージョンによってクオータ 0 のことがあるため、デプロイ可能なリージョンを `クォータ` 画面で事前に確認すること。
+```powershell
+az cognitiveservices account deployment create `
+  --name $AOAI_NAME `
+  --resource-group $RG `
+  --deployment-name $CHAT_DEPLOY `
+  --model-name "gpt-4o" `
+  --model-version "2024-11-20" `
+  --model-format OpenAI `
+  --sku-name "GlobalStandard" `
+  --sku-capacity 50
+```
+
+#### `gpt-4.1` が引ける場合
+
+§0-3 で `OpenAI.GlobalStandard.gpt-4.1` の limit が正の値で表示されていれば、以下に差し替え可能です。`$CHAT_DEPLOY` を `"gpt-4.1"` に変更してから実行してください。
+
+```powershell
+az cognitiveservices account deployment create `
+  --name $AOAI_NAME `
+  --resource-group $RG `
+  --deployment-name $CHAT_DEPLOY `
+  --model-name "gpt-4.1" `
+  --model-version "2025-04-14" `
+  --model-format OpenAI `
+  --sku-name "GlobalStandard" `
+  --sku-capacity 50
+```
+
+> 📝 個人 Azure サブスクリプションは Anthropic Claude / GPT-4.1 などプレミアムモデルが初期クオータ 0 のことが多く、本ガイドでは確実に動く `gpt-4o` を既定にしています。コードは `.env` で `AZURE_OPENAI_CHAT_DEPLOYMENT` を読むので、後日上位モデルのクオータが通れば 1 行変更で差し替え可能。
 
 ### 2-3. text-embedding-3-large のデプロイ
 
-同じ手順で、もう一つデプロイします。
-
-| 項目 | 値 |
-|---|---|
-| モデル | `text-embedding-3-large` |
-| デプロイ名 | **`text-embedding-3-large`** |
-| デプロイの種類 | Standard |
-| TPM（1分あたりトークン数） | 30K |
+```powershell
+az cognitiveservices account deployment create `
+  --name $AOAI_NAME `
+  --resource-group $RG `
+  --deployment-name $EMBED_DEPLOY `
+  --model-name "text-embedding-3-large" `
+  --model-version "1" `
+  --model-format OpenAI `
+  --sku-name "Standard" `
+  --sku-capacity 30
+```
 
 ### 2-4. エンドポイントとキーを取得
 
-Project 画面 → 「**概要**」または「**設定**」→ Foundry エンドポイントと API キーをコピー。
+```powershell
+$AOAI_ENDPOINT = az cognitiveservices account show `
+  --name $AOAI_NAME --resource-group $RG `
+  --query "properties.endpoint" -o tsv
 
-メモする内容：
+$AOAI_KEY = az cognitiveservices account keys list `
+  --name $AOAI_NAME --resource-group $RG `
+  --query "key1" -o tsv
 
-```
-AZURE_OPENAI_ENDPOINT  ← エンドポイント URL
-AZURE_OPENAI_API_KEY   ← キー
+Write-Host "AZURE_OPENAI_ENDPOINT=$AOAI_ENDPOINT"
+Write-Host "AZURE_OPENAI_API_KEY=$AOAI_KEY"
 ```
 
 ---
 
 ## 3. Azure Cosmos DB for NoSQL
 
-### 3-1. アカウント作成
+### 3-1. アカウント作成（Serverless + Vector Search 有効）
 
-ポータル → 「Azure Cosmos DB」→ **+ 作成** → **Azure Cosmos DB for NoSQL** を選択
+```powershell
+az cosmosdb create `
+  --name $COSMOS_NAME `
+  --resource-group $RG `
+  --locations regionName=$LOCATION failoverPriority=0 isZoneRedundant=False `
+  --capabilities EnableServerless EnableNoSQLVectorSearch `
+  --default-consistency-level Session
+```
 
-| 項目 | 値 |
-|---|---|
-| アカウント名 | `cosmos-sales-agent-<好きな文字列>`（グローバル一意） |
-| リージョン | `East US 2` |
-| 容量モード | **Serverless** ★コスト最小 |
-| **Free Tier 割引適用** | **オン** ★1サブスクリプションに1個だけ無料 |
-
-> **Free Tier** は 1000 RU/s + 25GB が無料になる枠です。1サブスクリプションに1個までしか作れないので、ぜひこのリソースで使ってください。
-
-「**機能**」タブで **「Vector Search for NoSQL API」** を **有効化**（プレビュー機能）。
-
-→ 「確認及び作成」→ 作成
+> 💡 Serverless はアイドル時のコストが 0 になります。Free Tier 割引は Provisioned 専用のため Serverless とは併用不可。Serverless の方が個人利用にはむしろ安く済みます。
 
 ### 3-2. データベース作成
 
-作成完了後 → 「**データ エクスプローラー**」→ 「**+ New Database**」
-
-| 項目 | 値 |
-|---|---|
-| Database id | **`sales-agent`** |
-| スループット | （Serverless なので不要） |
-
-### 3-3. コンテナを4つ作成
-
-「**+ New Container**」を 4 回繰り返し、以下を作成：
-
-| Container id | Partition key |
-|---|---|
-| `customers` | `/companyId` |
-| `meetings` | `/companyId` |
-| `documents` | `/companyId` |
-| `cases` | `/industry` |
-
-### 3-4. `cases` コンテナに Vector Index を設定（重要）
-
-`cases` コンテナ → 「**Settings**」→ 「**Container Vector Policy**」 に以下を貼り付け：
-
-```json
-{
-  "vectorEmbeddings": [
-    {
-      "path": "/embedding",
-      "dataType": "float32",
-      "distanceFunction": "cosine",
-      "dimensions": 1536
-    }
-  ]
-}
+```powershell
+az cosmosdb sql database create `
+  --account-name $COSMOS_NAME `
+  --resource-group $RG `
+  --name $COSMOS_DB
 ```
 
-続いて「**Indexing Policy**」を編集して vector index を追加：
+### 3-3. コンテナ 2 つを作成（普通のコンテナ）
 
-```json
-{
-  "indexingMode": "consistent",
-  "automatic": true,
-  "includedPaths": [{"path": "/*"}],
-  "excludedPaths": [
-    {"path": "/_etag/?"},
-    {"path": "/embedding/*"}
-  ],
-  "vectorIndexes": [
-    {"path": "/embedding", "type": "diskANN"}
-  ]
-}
+`customers` と `meetings` の 2 つを作ります。コード（`tools/customer_history.py` / `tools/meeting_record.py`）が参照するコンテナのみ作るのがポイント。
+
+```powershell
+az cosmosdb sql container create `
+  --account-name $COSMOS_NAME --resource-group $RG `
+  --database-name $COSMOS_DB `
+  --name customers --partition-key-path "/companyId"
+
+az cosmosdb sql container create `
+  --account-name $COSMOS_NAME --resource-group $RG `
+  --database-name $COSMOS_DB `
+  --name meetings --partition-key-path "/companyId"
 ```
 
-> **次元数 1536 にしている理由**：`text-embedding-3-large` のデフォルト出力は 3072 次元ですが、API 呼び出し時に `dimensions=1536` を指定すると 1536 次元に圧縮できます。1536 次元なら DiskANN の上限内で高速・省ストレージです。**コード側で必ず `dimensions=1536` を指定**してください。
+### 3-4. `cases` コンテナを Vector Index 付きで作成（重要）
+
+> ⚠️ **Azure CLI からは vector embedding policy を設定できません。**
+> `az cosmosdb sql container create` は 2026 年 5 月時点で `--vector-embedding-policy` 引数を**サポートしていません**（`cosmosdb-preview` 拡張を入れても同じ）。
+> そのため、ARM REST API を `az rest` で直接叩いて作成します。
+
+#### 3-4-1. コンテナ定義 JSON を書き出す
+
+`Out-File -Encoding utf8` は PowerShell 5.1 では **BOM 付き** UTF-8 を出力し、`az rest --body @file` で稀に問題になります。`[System.IO.File]::WriteAllText` で BOM 無し UTF-8 として書き出します。
+
+```powershell
+$containerDef = @'
+{
+  "properties": {
+    "resource": {
+      "id": "cases",
+      "partitionKey": { "paths": ["/industry"], "kind": "Hash" },
+      "vectorEmbeddingPolicy": {
+        "vectorEmbeddings": [{
+          "path": "/embedding",
+          "dataType": "float32",
+          "distanceFunction": "cosine",
+          "dimensions": 1536
+        }]
+      },
+      "indexingPolicy": {
+        "indexingMode": "consistent",
+        "automatic": true,
+        "includedPaths": [{"path": "/*"}],
+        "excludedPaths": [
+          {"path": "/\"_etag\"/?"},
+          {"path": "/embedding/*"}
+        ],
+        "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}]
+      }
+    },
+    "options": { "throughput": 400 }
+  }
+}
+'@
+
+[System.IO.File]::WriteAllText(
+  "$PWD\cases-container.json",
+  $containerDef,
+  [System.Text.UTF8Encoding]::new($false)  # $false = BOM 無し
+)
+```
+
+#### 3-4-2. ARM REST で PUT
+
+```powershell
+$SUB = az account show --query id -o tsv
+$uri = "https://management.azure.com/subscriptions/$SUB/resourceGroups/$RG" + `
+       "/providers/Microsoft.DocumentDB/databaseAccounts/$COSMOS_NAME" + `
+       "/sqlDatabases/$COSMOS_DB/containers/cases?api-version=2024-08-15"
+
+az rest --method put --uri $uri --body "@cases-container.json"
+```
+
+#### 3-4-3. ベクター設定の検証
+
+```powershell
+az cosmosdb sql container show `
+  --account-name $COSMOS_NAME --resource-group $RG `
+  --database-name $COSMOS_DB --name cases `
+  --query "{pk:resource.partitionKey.paths, vectorPath:resource.vectorEmbeddingPolicy.vectorEmbeddings[0].path, vectorDim:resource.vectorEmbeddingPolicy.vectorEmbeddings[0].dimensions, vectorIdx:resource.indexingPolicy.vectorIndexes[0].path}" `
+  -o json
+```
+
+期待出力例:
+
+```json
+{ "pk": ["/industry"], "vectorPath": "/embedding", "vectorDim": 1536, "vectorIdx": "/embedding" }
+```
+
+> **次元数 1536 にしている理由**：`text-embedding-3-large` のデフォルト出力は 3072 次元ですが、API 呼び出し時に `dimensions=1536` を指定すると 1536 次元に圧縮できます。1536 次元なら DiskANN の上限内で高速・省ストレージです。**コード側で必ず `dimensions=1536` を指定**してください（`src/agent_first_meeting/tools/case_search.py` で対応済み）。
 
 ### 3-5. エンドポイントとキーを取得
 
-Cosmos DB アカウント → 「**Keys**」メニュー → **URI** と **Primary Key** をコピー。
+```powershell
+$COSMOS_ENDPOINT = az cosmosdb show `
+  --name $COSMOS_NAME --resource-group $RG `
+  --query "documentEndpoint" -o tsv
 
-メモする内容：
+$COSMOS_KEY = az cosmosdb keys list `
+  --name $COSMOS_NAME --resource-group $RG `
+  --query "primaryMasterKey" -o tsv
 
-```
-COSMOS_ENDPOINT  ← URI
-COSMOS_KEY       ← Primary Key
+Write-Host "COSMOS_ENDPOINT=$COSMOS_ENDPOINT"
+Write-Host "COSMOS_KEY=$COSMOS_KEY"
 ```
 
 ---
 
 ## 4. Azure Blob Storage
 
-### 4-1. アカウント作成
+### 4-1. ストレージアカウント作成
 
-ポータル → 「ストレージ アカウント」→ **+ 作成**
-
-| 項目 | 値 |
-|---|---|
-| ストレージ アカウント名 | `stsalesagent<random>`（小文字英数のみ、グローバル一意） |
-| リージョン | `East US 2` |
-| パフォーマンス | Standard |
-| 冗長性 | **LRS** ★最安 |
-
-→ 「確認及び作成」→ 作成
+```powershell
+az storage account create `
+  --name $STORAGE_NAME `
+  --resource-group $RG `
+  --location $LOCATION `
+  --sku Standard_LRS `
+  --kind StorageV2 `
+  --allow-blob-public-access false
+```
 
 ### 4-2. コンテナ作成
 
-ストレージアカウント → 「**コンテナー**」→ **+ コンテナー**
-
-| 項目 | 値 |
-|---|---|
-| 名前 | `generated-documents` |
-| パブリックアクセスレベル | **プライベート** |
-
-### 4-3. 接続情報を取得
-
-ストレージアカウント → 「**エンドポイント**」メニュー → **Blob service** の URL をコピー。
-
-メモする内容：
-
-```
-BLOB_ACCOUNT_URL  ← Blob service の URL
+```powershell
+az storage container create `
+  --account-name $STORAGE_NAME `
+  --name $BLOB_CONTAINER `
+  --auth-mode login
 ```
 
-> 認証はコード側で `azure-identity` の `DefaultAzureCredential` を使うため、API キーは保存しません（次の 4-4 のロール付与で代替）。
+### 4-3. ロールを自分に付与（DefaultAzureCredential で書き込めるようにする）
 
-### 4-4. 自分のアカウントにロールを付与
+```powershell
+$ME = az ad signed-in-user show --query id -o tsv
+$STORAGE_ID = az storage account show `
+  --name $STORAGE_NAME --resource-group $RG `
+  --query id -o tsv
 
-ストレージアカウント → 「**アクセス制御 (IAM)**」→ 「**+ 追加**」→ 「**ロールの割り当ての追加**」
+az role assignment create `
+  --assignee $ME `
+  --role "Storage Blob Data Contributor" `
+  --scope $STORAGE_ID
+```
 
-| 項目 | 値 |
-|---|---|
-| ロール | **ストレージ BLOB データ共同作成者** |
-| メンバー | 自分のユーザー（`mintyobi@gmail.com`） |
+> 🛑 このロール付与を忘れると、ローカル開発時に Blob 書き込みで 403 エラーになります。
 
-→ 保存
+### 4-4. 接続情報を取得
 
-> このロール付与を忘れると、ローカル開発時に Blob 書き込みで 403 エラーになります。
+```powershell
+$BLOB_URL = az storage account show `
+  --name $STORAGE_NAME --resource-group $RG `
+  --query "primaryEndpoints.blob" -o tsv
+
+# SAS 付きダウンロード URL を発行したい場合はアカウントキーも取得
+$BLOB_KEY = az storage account keys list `
+  --account-name $STORAGE_NAME --resource-group $RG `
+  --query "[0].value" -o tsv
+
+Write-Host "BLOB_ACCOUNT_URL=$BLOB_URL"
+Write-Host "BLOB_ACCOUNT_KEY=$BLOB_KEY"
+```
+
+> 💡 `BLOB_ACCOUNT_KEY` を `.env` に入れると、生成 PowerPoint のダウンロード URL が SAS 付き（24時間有効）になります。空にすると `DefaultAzureCredential` で認証だけ通り、URL は素のものを返します（プライベートコンテナなので URL 直叩きでは開けません）。**ローカル開発では Key を入れる**のが手っ取り早いです。
 
 ---
 
 ## 5. .env への反映
 
-[agent-first-meeting/.env.example](../.env.example) をコピーして `.env` を作り、上記でメモした値を埋めます。
+ここまでで取得した値を `.env` に書き込みます。
 
-```bash
+```powershell
 cp agent-first-meeting/.env.example agent-first-meeting/.env
-# エディタで .env を開いて値を埋める
 ```
 
-| `.env` キー | 取得元 |
+エディタで `agent-first-meeting/.env` を開いて以下のように記入：
+
+| `.env` キー | 値 |
 |---|---|
-| `AZURE_OPENAI_ENDPOINT` | 2-4 で取得 |
-| `AZURE_OPENAI_API_KEY` | 2-4 で取得 |
-| `AZURE_OPENAI_CHAT_DEPLOYMENT` | `claude-sonnet-4-6`（2-2 で付けたデプロイ名） |
-| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | `text-embedding-3-large`（2-3 で付けたデプロイ名） |
-| `AZURE_OPENAI_API_VERSION` | `2024-12-01-preview`（既定でOK） |
-| `COSMOS_ENDPOINT` | 3-5 で取得 |
-| `COSMOS_KEY` | 3-5 で取得 |
+| `AZURE_OPENAI_ENDPOINT` | `$AOAI_ENDPOINT` の値 |
+| `AZURE_OPENAI_API_KEY` | `$AOAI_KEY` の値 |
+| `AZURE_OPENAI_CHAT_DEPLOYMENT` | §2-2 でデプロイ名（既定 `gpt-4o`） |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | `text-embedding-3-large` |
+| `AZURE_OPENAI_API_VERSION` | `2024-12-01-preview` |
+| `COSMOS_ENDPOINT` | `$COSMOS_ENDPOINT` の値 |
+| `COSMOS_KEY` | `$COSMOS_KEY` の値 |
 | `COSMOS_DATABASE` | `sales-agent` |
-| `BLOB_ACCOUNT_URL` | 4-3 で取得 |
+| `BLOB_ACCOUNT_URL` | `$BLOB_URL` の値 |
 | `BLOB_CONTAINER` | `generated-documents` |
+| `BLOB_ACCOUNT_KEY` | `$BLOB_KEY` の値（任意、SAS 発行用） |
+
+PowerShell から `.env` を自動生成したい場合はこんな書き方も可能（PS 5.1 でも BOM 無し UTF-8 で書き出します）：
+
+```powershell
+$envText = @"
+AZURE_OPENAI_ENDPOINT=$AOAI_ENDPOINT
+AZURE_OPENAI_API_KEY=$AOAI_KEY
+AZURE_OPENAI_CHAT_DEPLOYMENT=$CHAT_DEPLOY
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT=$EMBED_DEPLOY
+AZURE_OPENAI_API_VERSION=2024-12-01-preview
+COSMOS_ENDPOINT=$COSMOS_ENDPOINT
+COSMOS_KEY=$COSMOS_KEY
+COSMOS_DATABASE=$COSMOS_DB
+BLOB_ACCOUNT_URL=$BLOB_URL
+BLOB_CONTAINER=$BLOB_CONTAINER
+BLOB_ACCOUNT_KEY=$BLOB_KEY
+APP_LOG_LEVEL=INFO
+"@
+
+[System.IO.File]::WriteAllText(
+  "$PWD\agent-first-meeting\.env",
+  $envText,
+  [System.Text.UTF8Encoding]::new($false)
+)
+```
 
 > ⚠️ `.env` は絶対に Git にコミットしないでください（`.gitignore` で除外済み）。
 
+### 動作確認用シードデータの投入
+
+`.env` を埋めたら、最初のスモークテスト用にダミーデータを入れておきます。
+
+```powershell
+cd agent-first-meeting
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install --upgrade pip wheel setuptools
+pip install -e ".[dev]"
+
+python scripts/check_foundry.py        # Foundry 疎通
+python scripts/seed_cases.py           # cases に 1件 投入（vector search 動作確認込み）
+python scripts/seed_customer.py        # customers / meetings に既存顧客 1件 投入
+python scripts/check_vector_search.py  # vector 検索が動くことを確認
+python scripts/check_pptx_blob.py      # Blob への pptx アップロードを確認
+```
+
 ---
 
-## 6. Container Apps（後回し）
+## 6. 後片付け（リソース削除）
 
-PoC コードはローカルで動作確認するため、**Container Apps は PoC が動いてから** プロビジョニングします。順序的には Phase 3 の後で十分です。
+ハッカソン終了後にコストを止めたい場合、リソースグループごと一気に消すのが安全・確実です。
+
+```powershell
+az group delete --name $RG --yes --no-wait
+```
 
 ---
 
@@ -294,7 +496,7 @@ PoC コードはローカルで動作確認するため、**Container Apps は P
 |---|---|
 | Foundry: GPT-4.1 | 入力 $2 / 出力 $8（per 1M tokens）。デモ程度で月 $3〜$8 |
 | Foundry: text-embedding-3-large | $0.13 / 1M tokens。ほぼ無視できる |
-| Cosmos DB Serverless + Free Tier | 1000 RU/s + 25GB が **無料** |
+| Cosmos DB Serverless | $0.25 / 1M RU、25GB まで $0.25/GB/月。デモ用途は月 $1 程度 |
 | Blob Storage LRS | 数十GB 程度なら月 $1 未満 |
 | **合計目安** | **月 $10〜$20**（$200 クレジットで余裕） |
 
@@ -304,9 +506,13 @@ PoC コードはローカルで動作確認するため、**Container Apps は P
 
 | 症状 | 原因と対処 |
 |---|---|
-| デプロイ画面で「クオータ不足」と出てモデルが選べない | クオータ画面（管理センター → Quota）でリージョン × モデルごとの割当量を確認。割当 0 の場合は別リージョン・別モデル（`gpt-4o-mini` 等）を試す or 「クォータの要求」から申請。 |
-| Anthropic Claude モデルが選択肢にない／全リージョン 0 | 個人サブスクリプションでは Anthropic 系は初期クオータ 0 で要申請。本プロジェクトはこの理由で Claude を諦め GPT-4.1 を採用。 |
-| Cosmos DB 作成時に Vector Search 設定項目が見当たらない | アカウント作成後でも「機能」タブから **「Vector Search for NoSQL API」** を有効化できる。 |
-| Cosmos DB の Free Tier が選べない | 1サブスクリプションに 1 個まで。既に他で使っている場合は不可。Serverless だけでも十分安価。 |
-| Blob 書き込みで 403 エラー | 4-4 のロール割り当て（**ストレージ BLOB データ共同作成者**）を自分のアカウントに付与し忘れている。 |
-| `az login` していないとローカル開発で認証エラー | ターミナルで `az login` を実行（`azure-cli` のインストールが必要）。 |
+| `az cognitiveservices account deployment create` で「クオータ不足」 | §0-3 のクオータ確認コマンドでリージョン × SKU × モデルの割当量を確認。`OpenAI.GlobalStandard.gpt-4.1` などが limit=0 なら、本ガイドが既定にしている `gpt-4o` に切り替え。 |
+| Anthropic Claude / GPT-4.1 などプレミアムモデルが全リージョンでクオータ 0 | 個人サブスクリプションでは多くの上位モデルが初期クオータ 0 で要申請。本ガイドは確実に動く `gpt-4o` を既定としている。 |
+| `--vector-embedding-policy` が認識されない | **Azure CLI は `az cosmosdb sql container create --vector-embedding-policy` を 2026 年 5 月時点で未サポート**（`cosmosdb-preview` 拡張を入れても同じ）。§3-4 の `az rest` 経由で ARM REST API を直接叩くこと。 |
+| `Cosmos DB 作成時に `EnableNoSQLVectorSearch` が unknown` と言われる | Azure CLI 本体が古い。`az upgrade` で最新版（2.60+）へ。 |
+| Storage アカウント作成が `MissingSubscriptionRegistration` で失敗 | §0-2 の `Microsoft.Storage` 登録が `Registering` のまま。`az provider show -n Microsoft.Storage --query registrationState -o tsv` が `Registered` になるまで（数分かかることあり）待つ。 |
+| Cosmos DB の Free Tier を使いたい | Free Tier は Provisioned 専用なので Serverless とは併用不可。デモ用途は Serverless だけで十分安価。どうしても Free Tier 使いたい場合は `--capabilities` から `EnableServerless` を外し、`--enable-free-tier true` を付け、各コンテナに `--throughput 400` 等を指定する。 |
+| `cases-container.json` を `az rest` に渡したら JSON パースエラー | `Out-File -Encoding utf8` が PowerShell 5.1 で BOM 付き UTF-8 を出力したのが原因。§3-4-1 の `[System.IO.File]::WriteAllText` で BOM 無しで書き出すこと。 |
+| Blob 書き込みで 403 エラー | (a) `.env` に `BLOB_ACCOUNT_KEY` を入れていれば本来不要だが、Managed Identity 系で動かしているなら 4-3 のロール割り当て（**Storage Blob Data Contributor**）忘れ。ロール反映には数十秒〜数分かかることも。 |
+| ローカル開発で `DefaultAzureCredential` が失敗する | ターミナルで `az login` が必要。ロール反映待ちなら数分置いてから再実行。`.env` に `BLOB_ACCOUNT_KEY` を入れる方が手っ取り早い（ローカル開発限定）。 |
+| `--custom-domain` を指定し忘れた | `https://<region>.api.cognitive.microsoft.com/` 形式になり、Foundry の OpenAI クライアントから叩けない。`az cognitiveservices account update --custom-domain $AOAI_NAME` で後付け可能。 |


### PR DESCRIPTION
## Summary

Azure CLI で実機構築（rg-sales-agent-hack526a / eastus2）→破棄まで通したうえで、ドキュメントと実コマンドの乖離を解消しました。

- 既定チャットモデルを **gpt-4.1 → gpt-4o** に変更（個人サブスクで gpt-4.1 クオータが全リージョン 0 のケースが多い）
- **vector index 付き `cases` コンテナ作成を `az rest` 経由に書き換え**（`az cosmosdb sql container create` は `--vector-embedding-policy` を未サポート、`cosmosdb-preview` 1.6.2 でも同様）
- 未使用の `documents` コンテナ作成を削除（コード参照は `cases`/`customers`/`meetings` のみ）
- §0-3 を新設してモデル可用性・クオータの**事前確認手順**を追加
- PowerShell 5.1 の **BOM 付き UTF-8 問題**を回避（`Out-File` → `[System.IO.File]::WriteAllText`）
- `Microsoft.Storage` プロバイダー登録の待ち時間を §0-2 に追記
- 「`az upgrade` で `--vector-embedding-policy` が認識される」誤った記述を削除
- README.md の後片付け手順を `$RG` 変数参照に統一

## Test plan

- [x] Azure CLI 2.86.0 + cosmosdb-preview 1.6.2 環境で `az cosmosdb sql container create --vector-embedding-policy` が未対応であることを確認
- [x] 修正後の手順通りに rg-sales-agent-hack526a を eastus2 に構築 → gpt-4o + text-embedding-3-large デプロイ・Cosmos DB 4 リソース（DB + cases/customers/meetings）作成・Blob 作成まで通過
- [x] `cases` コンテナの vector embedding policy / vector index が正しく適用されていることを `az cosmosdb sql container show` で検証
- [x] `scripts/check_foundry.py` `seed_cases.py` `seed_customer.py` `check_vector_search.py` `check_pptx_blob.py` `test_api.py` の 6 スモークテストが全て成功
- [x] FastAPI 経由の E2E（SSE）で PPTX 生成 + Blob SAS URL 返却まで動作
- [x] 検証後 `az group delete` で全リソース破棄済み（課金影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)