### PR TITLE
feat: follow-up エージェントを本実装（outcomes 記録 + 継続提案）

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,35 +67,29 @@ flowchart TD
 graph TD
     ROOT["📁 agentic_ai_for_hackathon/　ルートリポジトリ"]
  
-    ROOT --> A["📁 agent-first-meeting/　初回面談エージェント"]
-    ROOT --> B["📁 agent-follow-up/　フォローアップエージェント"]
-    ROOT --> F["📁 frontend/　Ex.) Streamlit UI"]
+    ROOT --> A["📁 agent-first-meeting/　面談支援エージェント本体<br>（first / followup 両モード）"]
+    ROOT --> F["📁 frontend/　Streamlit UI"]
     ROOT --> D["📁 docs/　プロジェクト全体のドキュメント"]
-    ROOT --> DC["🐳 docker-compose.yml"]
-    ROOT --> ENV["📄 .env.example"]
  
     A --> A1["📁 src/　ソースコード本体"]
     A --> A2["📁 docs/　このエージェントの仕様書"]
     A --> A3["📁 tests/　テストコード"]
     A --> A4["📄 pyproject.toml"]
  
-    B --> B1["📁 src/　ソースコード本体"]
-    B --> B2["📁 docs/　このエージェントの仕様書"]
-    B --> B3["📁 tests/　テストコード"]
-    B --> B4["📄 pyproject.toml"]
- 
-    F --> F1["📁 src/pages/　各画面"]
     F --> F2["📄 main.py"]
+    F --> F4["📄 pyproject.toml"]
 ```
 
 ### 各ディレクトリの役割
  
 | ディレクトリ | 担当者 | 役割 |
 |---|---|---|
-| `agent-first-meeting/` | ともや | 初回面談向け：類似事例検索・アポ資料生成 |
-| `agent-follow-up/` | 未定 | 2回目以降：顧客情報参照・提案資料生成 |
+| `agent-first-meeting/` | ともや | 面談支援エージェント本体。**初回（first）と 2回目以降（followup）の両モードに対応**し、`meetingStatus` で切り替える（類似事例検索・資料生成・面談履歴の参照／記録） |
 | `frontend/` | 未定 | Streamlit による営業担当者向けUI |
 | `docs/` | 共同 | システム全体のドキュメント |
+
+> 当初は 2回目以降を別ディレクトリ `agent-follow-up/` に分ける構想だったが、利用ツールが
+> ほぼ共通のため、`agent-first-meeting/` 内に followup モードとして統合した。
 
 ### `src/` と `docs/` の使い分け
  
@@ -115,27 +109,27 @@ graph TD
  
 ## 開発フロー
  
-2人が**並行して**それぞれのエージェントを開発し、最終的にルートリポジトリへ統合します。
- 
+エージェント本体（first → followup の順でモードを拡充）と UI を**並行して**開発し、
+`develop` へ集約して `main` にリリースします。
+
 ```mermaid
 flowchart LR
     subgraph Phase1["Phase 1　並行開発"]
-        A["agent-first-meeting/ 開発"]
-        B["agent-follow-up/ 開発"]
+        A["agent-first-meeting/<br>first → followup モード拡充"]
+        B["frontend/<br>Streamlit UI"]
     end
  
     subgraph Phase2["Phase 2　インターフェース合わせ"]
-        C["APIの入出力形式を確認・調整"]
+        C["API の入出力形式を確認・調整<br>（meetingStatus / SSE）"]
     end
  
-    subgraph Phase3["Phase 3　統合"]
-        D["sales-agent/ <br>にコードをマージ"]
+    subgraph Phase3["Phase 3　統合・リリース"]
         E["結合テスト"]
-        F["リリース🚀"]
+        F["develop → main リリース🚀"]
     end
  
     Phase1 --> Phase2 --> Phase3
-    D --> E --> F
+    E --> F
 ```
 
 ## 統合をスムーズにするための事前合意事項
@@ -174,22 +168,22 @@ gitGraph
     checkout develop
     commit id: "setup"
  
-    branch feature/first-meeting-agent
-    checkout feature/first-meeting-agent
-    commit id: "case_searcher 実装"
-    commit id: "document_generator 実装"
+    branch feature/init-agent-first-meeting
+    checkout feature/init-agent-first-meeting
+    commit id: "case_search 実装"
+    commit id: "document_gen / 面談保存 実装"
     checkout develop
-    merge feature/first-meeting-agent id: "Merge A"
+    merge feature/init-agent-first-meeting id: "Merge first"
  
-    branch feature/follow-up-agent
-    checkout feature/follow-up-agent
-    commit id: "info_retriever 実装"
-    commit id: "proposal_generator 実装"
+    branch feature/followup-agent
+    checkout feature/followup-agent
+    commit id: "outcomes 記録ツール"
+    commit id: "継続提案プロンプト本実装"
     checkout develop
-    merge feature/follow-up-agent id: "Merge B"
+    merge feature/followup-agent id: "Merge followup"
  
     checkout main
-    merge develop id: "v1.0.0 リリース"
+    merge develop id: "リリース"
 ```
 
 ### ブランチ命名規則
@@ -289,10 +283,8 @@ Phase 3（統合時）の具体的な作業手順です。
  
 ```mermaid
 flowchart TD
-    S1["各エージェントの<br>最終コードを確認"] --> S2["agent-first-meeting/src/<br>をルートにコピー"]
-    S2 --> S3["agent-follow-up/src/<br>をルートにコピー"]
-    S3 --> S4["docker-compose.yml を更新"]
-    S4 --> S5["結合テストを実行<br>tests/integration/"]
+    S1["agent-first-meeting の<br>最終コードを確認<br>（first / followup 両モード）"] --> S2["frontend と結線<br>（meetingStatus / SSE）"]
+    S2 --> S5["結合テストを実行"]
     S5 --> S6{テスト通過？}
     S6 -->|✅ YES| S7["develop へマージ<br>→ main へリリース"]
     S6 -->|❌ NO| S8["問題箇所を修正<br>→ S5 に戻る"]
@@ -308,8 +300,7 @@ flowchart TD
 | プロジェクト概要 | `docs/overview.md` | システム全体の目的・構成 |
 | API仕様（全体） | `docs/api.md` | 全エンドポイントの一覧 |
 | 環境構築手順 | `docs/setup.md` | 詳細なセットアップ手順 |
-| 初回エージェント仕様 | `agent-first-meeting/docs/api.md` | エンドポイント・入出力定義 |
-| フォローアップ仕様 | `agent-follow-up/docs/api.md` | エンドポイント・入出力定義 |
+| 面談エージェント仕様（first / followup） | `agent-first-meeting/docs/api.md` | エンドポイント・入出力定義（両モード） |
 
 ### `docs/api.md` の書き方テンプレート（仮）
  

--- a/agent-first-meeting/docs/api.md
+++ b/agent-first-meeting/docs/api.md
@@ -23,6 +23,12 @@
 | `scale` | string | ✅ | 企業規模（例: 中小企業, 大企業） |
 | `knownInfo` | string | - | 事前に分かっている課題感などのフリーテキスト |
 | `salesperson` | string | - | 担当営業名 |
+| `homepageUrl` | string | - | 顧客公式 HP。本文を取得して提案根拠に使う |
+| `contactName` / `contactDepartment` / `contactPosition` | string | - | 取引相手の氏名 / 部署 / 役職 |
+| `meetingStatus` | string | - | `"first"`（既定）= 初回、`"followup"` = 2回目以降 |
+| `lastMeetingNotes` | string | - | （followup 時）前回面談の実績メモ。詳細は下記 |
+
+> このエンドポイントは **初回（first）と 2回目以降（followup）の両モード** を `meetingStatus` で切り替える単一窓口です。
 
 ### レスポンス（SSE）
 
@@ -79,3 +85,39 @@ event: done         data: {
   }
 }
 ```
+
+## follow-up（2回目以降）モード
+
+`meetingStatus: "followup"` を指定すると、継続提案用のエージェントが起動する。
+
+### 前提チェック
+
+過去の面談（`meetings`）が 1 件も無い顧客に対して followup を呼ぶと、エージェントを
+起動せず即座にエラーを返す（`error.code = "NoPreviousMeeting"`）。先に初回（first）を
+実施しておく必要がある。
+
+### 前回実績（outcomes）の記録
+
+`lastMeetingNotes` に前回面談で実際に起きたこと（反応・合意事項・宿題など）を渡すと、
+エージェントが **`record_meeting_outcomes`** ツールで直近 meeting の `outcomes` を埋め、
+`status` を `done` に更新する。これにより「前回の成果を踏まえた継続提案」が成立する。
+
+- `lastMeetingNotes` を省略した場合は、既に `meetings` に記録済みの `outcomes` を根拠に使う。
+- 今回生成した meeting の `outcomes` は `null` で保存され、次回の followup 呼び出し時に
+  改めて `lastMeetingNotes` 経由で埋められる契約。
+
+### リクエスト例（followup）
+
+```json
+{
+  "companyName": "株式会社既存お得意様",
+  "industry": "製造業",
+  "scale": "中小企業",
+  "salesperson": "佐々木",
+  "meetingStatus": "followup",
+  "lastMeetingNotes": "経営層は前向き。技能継承を最優先課題と再確認。RAG 事例の提示を依頼された。"
+}
+```
+
+`done` イベントの `data.invokedTools` には、初回と異なり `get_customer_history` が必須で含まれる
+（`lastMeetingNotes` を渡した場合は `record_meeting_outcomes` も呼ばれる）。

--- a/agent-first-meeting/src/agent_first_meeting/_meeting_select.py
+++ b/agent-first-meeting/src/agent_first_meeting/_meeting_select.py
@@ -1,0 +1,28 @@
+"""outcomes 記録の対象 meeting を選ぶ純ロジック.
+
+`_company_id.py` と同じく azure 系を import しない純粋モジュールに分離して、
+重い依存なしで unit test できるようにする。
+"""
+from typing import Any
+
+
+def select_target_meeting(
+    meetings: list[dict[str, Any]], round_num: int | None
+) -> dict[str, Any] | None:
+    """outcomes を書き込む対象の meeting を選ぶ.
+
+    Args:
+        meetings: 同一顧客の meeting ドキュメント一覧（順序は問わない）。
+        round_num: 対象の round。None または 0 以下なら最新（最大 round）を対象にする。
+
+    Returns:
+        対象 meeting。候補が無い / 指定 round が見つからない場合は None。
+    """
+    if not meetings:
+        return None
+    if round_num is not None and round_num > 0:
+        for meeting in meetings:
+            if meeting.get("round") == round_num:
+                return meeting
+        return None
+    return max(meetings, key=lambda m: m.get("round", 0))

--- a/agent-first-meeting/src/agent_first_meeting/agent.py
+++ b/agent-first-meeting/src/agent_first_meeting/agent.py
@@ -102,26 +102,53 @@ FIRST_AGENT_INSTRUCTIONS = """\
 """
 
 
-# Phase 2 スケルトン：2回目以降の面談エージェント。
-# 中身は first と同じツール群を持つが、instructions だけ差し替えている。
-# 本実装は Phase 3 以降で詰める。
+# 2回目以降の面談エージェント。first と同じツール群を共有し、instructions で
+# 「前回 outcomes を踏まえた継続提案」に振る舞いを切り替える。
 FOLLOWUP_AGENT_INSTRUCTIONS = """\
 あなたは営業担当者の **2回目以降** の面談を支援する AI エージェントです。
-初回面談との違いは「前回までの outcomes と nextActions を必ず踏まえる」点です。
+初回との決定的な違いは「前回までに起きたこと（outcomes）と積み残し（nextActions）を
+必ず踏まえ、継続提案として一歩進める」点です。以下の流れで動いてください。
 
 1. **get_customer_history** で過去の取引履歴を必ず取得する
-   - meetings 配列が空なら、ユーザーに「初回面談を先に実施してください」と返して終了
-   - 直近の meeting の outcomes / nextActions を抽出する
-2. 必要に応じて **fetch_url_text** で HP を再取得（事業状況に変化がないか確認）
-3. 前回の nextActions を解決する提案を組み立て、必要なら
-   **search_similar_cases** で追加事例を取得
-4. **generate_pptx** で 6 スライド構成の継続提案資料を生成する。
-   industry_body / position_body は前回 outcomes を踏まえた論点で組み立てる。
-5. **save_meeting_record** で本回のレコードを保存（round は自動採番）
-6. ユーザーに対し、前回からの差分・今回の論点・次回アクションを報告
+   - meetings 配列が空なら継続提案は成り立たない。
+     「初回面談を先に実施してください」と伝えて終了する
+   - meetings は round 降順。直近 meeting の round / proposedTitle / outcomes /
+     nextActions / preMeetingDocumentUrl を読み取る
 
-※ このプロンプトは Phase 2 スケルトン。Phase 3 以降で本格的な
-継続提案ロジックに差し替える前提です。
+2. 入力に「前回面談メモ」がある場合は、**record_meeting_outcomes** で
+   直近 meeting の outcomes として保存する（round_num は省略＝最新が対象）
+   - これにより「前回の成果」が確定し、今回の提案の根拠になる
+   - メモが「（未記入）」または空なら呼ばない。その場合は履歴に既にある
+     outcomes をそのまま根拠に使う（outcomes も nextActions も無ければ、
+     前回は資料生成のみで実績未確定とみなして慎重に提案する）
+
+3. 必要に応じて **fetch_url_text** で HP を再取得し、前回からの事業状況の
+   変化（新規事業・プレスリリース等）を拾う（URL が無ければ飛ばす）
+
+4. 前回の nextActions を「解決・前進させる」観点で今回の論点を設計する。
+   裏付けが欲しければ **search_similar_cases** で追加事例を取得する
+
+5. **generate_pptx** で 6 スライド構成の継続提案資料を生成する
+   - **cover_title**: 継続提案だと分かるタイトル。前回テーマからの前進を示す
+     （例: 「技能継承 DX 第2次ご提案：PoC から本格導入へ」）
+   - **cover_subtitle**: 「<会社名> 様向け / <年月> / 担当: <営業名>（第<round+1>回）」
+   - **industry_body**: 前回 outcomes で判明した課題と、その後の業界動向を
+     踏まえた残課題・打ち手を 3〜5 行の箇条書き（改行区切り）
+   - **position_body**: 前回 nextActions への回答・進捗を、取引相手の役職に
+     響く形で 3〜5 行の箇条書き（改行区切り）
+
+6. **save_meeting_record** で今回のレコードを保存する（round は自動採番）
+   - next_actions には「今回の面談で確認・合意したい次の一手」を入れる
+     （今回の outcomes は後日また record_meeting_outcomes で埋まる契約）
+
+7. 最後に営業担当者へ簡潔に報告する
+   - 前回（round / テーマ / outcomes）からの差分
+   - 今回の継続提案タイトルと、その根拠（前回 nextActions / 参照事例）
+   - 生成資料の URL
+   - 今回の面談で確認すべきポイント（＝保存した next_actions）
+   - 保存された面談レコード ID
+
+ツールは必要なものを自分で判断して呼んでください。
 """
 
 

--- a/agent-first-meeting/src/agent_first_meeting/schemas.py
+++ b/agent-first-meeting/src/agent_first_meeting/schemas.py
@@ -46,6 +46,17 @@ class GenerateRequest(BaseModel):
         description="面談ステータス。'first' = 初回、'followup' = 2回目以降。",
     )
 
+    # follow-up 用：前回面談で実際に何が起きたか（outcomes 記録の入力）
+    last_meeting_notes: str = Field(
+        default="",
+        alias="lastMeetingNotes",
+        description=(
+            "（followup 時）前回面談の実績・反応・所感のメモ。"
+            "記入されていれば record_meeting_outcomes で前回 meeting の outcomes として保存され、"
+            "今回の継続提案の根拠になる。"
+        ),
+    )
+
 
 def to_user_message(req: GenerateRequest) -> str:
     """ユーザー向けプロンプト形式に整形する."""
@@ -56,7 +67,7 @@ def to_user_message(req: GenerateRequest) -> str:
         if position_category
         else "不明（役職表記から判定できなかったので、あなたが判断してください）"
     )
-    return (
+    message = (
         f"以下の顧客の{status_label}に向けたアポ資料を作ってください。\n\n"
         f"- 会社名：{req.company_name}\n"
         f"- 業種：{req.industry}\n"
@@ -70,3 +81,7 @@ def to_user_message(req: GenerateRequest) -> str:
         f"- 担当営業：{req.salesperson or '（未記入）'}\n"
         f"- 面談ステータス：{status_label}\n"
     )
+    # follow-up のときだけ「前回面談メモ」を渡す（初回には存在しない情報なので出さない）
+    if req.meeting_status == "followup":
+        message += f"- 前回面談メモ：{req.last_meeting_notes or '（未記入）'}\n"
+    return message

--- a/agent-first-meeting/src/agent_first_meeting/tools/meeting_record.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/meeting_record.py
@@ -18,11 +18,13 @@ from azure.cosmos.exceptions import (
 from semantic_kernel.functions import kernel_function
 
 from agent_first_meeting._company_id import deterministic_company_id
+from agent_first_meeting._meeting_select import select_target_meeting
 from agent_first_meeting.config import settings
 
 logger = logging.getLogger(__name__)
 
 _MAX_ROUND_RETRY = 50
+_INTERNAL_FIELDS = {"_rid", "_self", "_etag", "_attachments", "_ts"}
 
 
 def _meeting_doc_id(company_id: str, round_num: int) -> str:
@@ -141,3 +143,59 @@ class MeetingRecordPlugin:
             f"failed to allocate meeting round number for {company_id} "
             f"after {_MAX_ROUND_RETRY} attempts"
         )
+
+    @kernel_function(
+        description=(
+            "実施済みの面談で得られた結果・所感（outcomes）を meetings コンテナに記録する。"
+            "save_meeting_record が outcomes=null で作ったレコードを後から埋めるためのツールで、"
+            "follow-up エージェントが『前回の outcomes を踏まえる』ための前提データになる。"
+            "round_num を省略（0）すると最新の面談を対象にする。"
+            "対象面談を done にし、更新した meetings ドキュメントの ID を返す。"
+        ),
+    )
+    def record_meeting_outcomes(
+        self,
+        company_name: Annotated[str, "顧客企業の正式名称"],
+        outcomes: Annotated[
+            str,
+            "実施した面談で判明した結果・反応・所感の要約（自由文）",
+        ],
+        round_num: Annotated[
+            int,
+            "対象の面談 round。0 以下なら最新の面談を対象にする。",
+        ] = 0,
+    ) -> Annotated[str, "outcomes を記録した meetings ドキュメントの ID"]:
+        company_id = deterministic_company_id(company_name)
+        meetings = list(
+            self._meetings.query_items(
+                query=(
+                    "SELECT * FROM c WHERE c.companyId = @id ORDER BY c.round DESC"
+                ),
+                parameters=[{"name": "@id", "value": company_id}],
+                partition_key=company_id,
+            )
+        )
+        target = select_target_meeting(meetings, round_num)
+        if target is None:
+            # 対象が無いのは「初回でまだ面談が無い」「指定 round が誤り」のいずれか。
+            # ここで例外を投げると API が実行全体を error にしてしまうため、
+            # エージェントが読んで判断できるメッセージを返すに留める（記録はスキップ）。
+            msg = (
+                f"記録対象の面談が見つかりませんでした "
+                f"(company={company_name}, round={round_num or 'latest'})。"
+                "outcomes の記録はスキップしました。"
+            )
+            logger.info("MeetingRecordPlugin: %s", msg)
+            return msg
+
+        body = {k: v for k, v in target.items() if k not in _INTERNAL_FIELDS}
+        body["outcomes"] = outcomes
+        body["status"] = "done"
+        body["updatedAt"] = datetime.now(timezone.utc).isoformat()
+        self._meetings.upsert_item(body)
+
+        logger.info(
+            "MeetingRecordPlugin: recorded outcomes id=%s company_id=%s round=%s",
+            body["id"], company_id, body.get("round"),
+        )
+        return body["id"]

--- a/agent-first-meeting/tests/test_meeting_select.py
+++ b/agent-first-meeting/tests/test_meeting_select.py
@@ -1,0 +1,50 @@
+"""`_meeting_select.select_target_meeting` のテスト.
+
+`_meeting_select` は azure 系を import しない純粋モジュールなので直接 import できる。
+"""
+from agent_first_meeting._meeting_select import select_target_meeting
+
+
+def _meetings() -> list[dict]:
+    # わざと round 順をバラバラに並べる（実装が順序に依存しないことを示す）
+    return [
+        {"id": "mtg_x_0002", "round": 2, "outcomes": None},
+        {"id": "mtg_x_0001", "round": 1, "outcomes": "前回の所感"},
+        {"id": "mtg_x_0003", "round": 3, "outcomes": None},
+    ]
+
+
+def test_returns_none_when_no_meetings():
+    """履歴が空なら対象なし."""
+    assert select_target_meeting([], None) is None
+    assert select_target_meeting([], 1) is None
+
+
+def test_picks_latest_when_round_omitted():
+    """round 未指定（None / 0 / 負）なら最大 round を返す."""
+    for round_arg in (None, 0, -1):
+        target = select_target_meeting(_meetings(), round_arg)
+        assert target is not None
+        assert target["round"] == 3
+        assert target["id"] == "mtg_x_0003"
+
+
+def test_picks_specific_round_when_given():
+    """正の round 指定なら、その round の meeting を返す."""
+    target = select_target_meeting(_meetings(), 1)
+    assert target is not None
+    assert target["round"] == 1
+    assert target["id"] == "mtg_x_0001"
+
+
+def test_returns_none_when_specified_round_missing():
+    """存在しない round を指定したら None."""
+    assert select_target_meeting(_meetings(), 99) is None
+
+
+def test_handles_missing_round_field():
+    """round フィールドが欠けた要素があっても落ちず、最大 round を選べる."""
+    meetings = [{"id": "a"}, {"id": "b", "round": 5}]
+    target = select_target_meeting(meetings, None)
+    assert target is not None
+    assert target["id"] == "b"

--- a/agent-first-meeting/tests/test_schemas.py
+++ b/agent-first-meeting/tests/test_schemas.py
@@ -92,6 +92,34 @@ def test_to_user_message_first_meeting_label():
     assert "2回目以降" not in msg
 
 
+def test_last_meeting_notes_alias_and_default():
+    """lastMeetingNotes は camelCase で受けられ、未指定なら空文字になること."""
+    req = GenerateRequest(**_minimum_payload())
+    assert req.last_meeting_notes == ""
+    req2 = GenerateRequest(
+        **_minimum_payload(meetingStatus="followup", lastMeetingNotes="前向きな反応")
+    )
+    assert req2.last_meeting_notes == "前向きな反応"
+
+
+def test_to_user_message_followup_includes_last_meeting_notes():
+    """followup のときは前回面談メモがプロンプトに含まれること."""
+    req = GenerateRequest(
+        **_minimum_payload(meetingStatus="followup", lastMeetingNotes="RAG 事例を依頼された")
+    )
+    msg = to_user_message(req)
+    assert "前回面談メモ" in msg
+    assert "RAG 事例を依頼された" in msg
+
+
+def test_to_user_message_first_meeting_omits_last_meeting_notes():
+    """初回のときは「前回面談メモ」行を出さないこと（前回が存在しないため）."""
+    req = GenerateRequest(**_minimum_payload(lastMeetingNotes="無視されるはず"))
+    msg = to_user_message(req)
+    assert "前回面談メモ" not in msg
+    assert "無視されるはず" not in msg
+
+
 def test_to_user_message_marks_missing_optional_fields():
     """任意項目が空のとき「（未記入）」が出ること."""
     req = GenerateRequest(**_minimum_payload())

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -79,6 +79,16 @@ with st.form("input_form"):
         height=120,
     )
 
+    last_meeting_notes = st.text_area(
+        "前回面談メモ（「2回目以降」の場合）",
+        placeholder=(
+            "前回面談で実際に起きたこと（相手の反応・合意事項・宿題など）。"
+            "記入すると前回実績として記録され、今回の継続提案の根拠になります。"
+            "初回の場合は空欄で構いません。"
+        ),
+        height=120,
+    )
+
     submitted = st.form_submit_button("🚀 資料を生成", type="primary")
 
 
@@ -98,6 +108,7 @@ if submitted:
         "contactDepartment": contact_department,
         "contactPosition": contact_position,
         "meetingStatus": "first" if meeting_status_label == "初回" else "followup",
+        "lastMeetingNotes": last_meeting_notes,
     }
 
     st.divider()


### PR DESCRIPTION
## 概要

スケルトンだった 2回目以降（followup）エージェントを本実装。`agent-first-meeting` 内の followup モードとして、初回と同じツール群を共有しつつ「前回の outcomes を踏まえた継続提案」を行えるようにした。

### 塞いだ穴
followup プロンプトは「前回 outcomes を踏まえる」前提だったが、`save_meeting_record` が常に `outcomes: null` を書き、それを更新する手段が存在しなかった。結果、踏まえるべき実績が永遠に空のまま動いていた。

## 変更内容

- **`record_meeting_outcomes` ツール追加**（`MeetingRecordPlugin`）：直近 or 指定 round の面談に実績(outcomes)を記録し `status` を `done` に更新。既存フィールドは保持。対象が無い場合は例外でなくスキップメッセージを返す。
- **`_meeting_select.py`**：対象 round 選択を azure 非依存の純ロジックに分離し unit test 可能化。
- **`GenerateRequest.lastMeetingNotes` 追加**：followup 時のみ `to_user_message` に反映。
- **`FOLLOWUP_AGENT_INSTRUCTIONS` 本実装**：履歴取得 → 前回実績記録 → 継続提案 → 保存 → 差分報告。
- **frontend**：「前回面談メモ」入力欄を追加し `lastMeetingNotes` を送信。
- **docs**：`docs/api.md` に followup モード仕様を追記。README の図を統合後の実態に更新。

## 動作確認（ローカルで Azure リソース `rg-sales-agent` に対し end-to-end 実走済み）

- [x] 純ロジック unit test 21 件パス（`select_target_meeting` / followup メッセージ整形）
- [x] 編集ファイルの `py_compile` OK、ruff F/I クリーン
- [x] **followup を API 直叩き + Streamlit UI の両方で実走**：`invokedTools` に `record_meeting_outcomes` 含む全ツール発火、`status: success`、PPTX 生成。
- [x] **`record_meeting_outcomes` が前回 meeting の outcomes を更新**（`proposedTitle` / `nextActions` は保持＝データ欠落なし）、新 round が自動採番されることを Cosmos の before/after で確認。
- [x] 新設の「前回面談メモ」入力欄から `lastMeetingNotes` がバックエンドまで配線されることを UI で確認。

> 関連: 検証中に発見した既存バグ（`cases` の vector search 未整備、その下流症状としてのレポート空表示）は別 PR #17 で修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)