### PR TITLE
fix: 面談資料の失効URL対策とエージェントUX改善（#22と統合）

### DIFF
--- a/agent-first-meeting/.env.example
+++ b/agent-first-meeting/.env.example
@@ -19,6 +19,12 @@ BLOB_CONTAINER=generated-documents
 # "Storage Blob Data Contributor" 以上のロールが必要。
 BLOB_ACCOUNT_KEY=
 
+# 提案資料の「自社商品 / 費用」スライドに入れる値（任意）。
+# 未設定なら商品名は汎用プレースホルダ、価格 0 は「別途お見積もり」と表示され、
+# 顧客向け資料に偽の金額が出ないようにしている。実値はここで上書きする。
+DEFAULT_PRODUCT_NAME=弊社ソリューション
+DEFAULT_PRODUCT_PRICE_JPY=0
+
 # アプリ設定
 APP_LOG_LEVEL=INFO
 # CORS で受け付けるオリジン（カンマ区切り）。本番では Streamlit / フロントの実ドメインに絞ること。

--- a/agent-first-meeting/src/agent_first_meeting/agent.py
+++ b/agent-first-meeting/src/agent_first_meeting/agent.py
@@ -29,20 +29,30 @@ class ToolResultTracker:
     SK 1.42 の `invoke_stream` では FunctionCallContent / FunctionResultContent
     が streaming items として流れない（最終テキスト応答のみ流れる）ため、
     Filter で kernel function 呼び出しをフックして必要な結果を集める。
+    あわせて (event_type, tool_name) を `events` に貯め、API 側が SSE で
+    ツール呼び出しの進捗を配信できるようにする。
     """
 
     def __init__(self) -> None:
         self.invoked_tools: set[str] = set()
         self.document_url: str | None = None
         self.meeting_id: str | None = None
+        # SSE で進捗表示するためのイベントキュー。(event_type, tool_name) を貯め、
+        # API 側が invoke_stream のチャンク間でドレインして yield する。
+        self.events: list[tuple[str, str]] = []
 
     async def hook(self, context, next):  # noqa: A002 (SK API は kw 名 'next' を要求)
-        await next(context)
         try:
             fn_name = context.function.name
         except Exception:  # noqa: BLE001
+            fn_name = None
+        if fn_name:
+            self.events.append(("tool", fn_name))
+        await next(context)
+        if not fn_name:
             return
         self.invoked_tools.add(fn_name)
+        self.events.append(("tool_result", fn_name))
         try:
             result_obj = context.result
             # SK の FunctionResult は .value 経由でアクセス
@@ -87,7 +97,7 @@ FIRST_AGENT_INSTRUCTIONS = """\
    - **cover_subtitle**: 「<会社名> 様向け / <年月> / 担当: <営業名>」の形式
    - **industry_body**: 業界トレンドと顧客の課題を 3〜5 行の箇条書き（1 行 = 1 項目、改行区切り）
    - **position_body**: 取引相手の役職（経営層 / 部門責任者 / 担当者）に響く論点を 3〜5 行の箇条書き
-   - ※ 自社商品スライドと費用スライドはプラグイン側で固定値（テスト商品 / 10 円）が入るので指定不要
+   - ※ 自社商品スライドと費用スライドはプラグイン側で既定値（config 設定。未設定時はプレースホルダ＝価格は「別途お見積もり」）が入るので指定不要
 5. **generate_pptx** で 6 スライド（表紙 / 目次 / 業界向け / 役職向け / 自社商品 / 費用）の提案資料を作成する
 6. **save_meeting_record** で生成資料と次回アクションを meetings コンテナに保存する
    （これが follow-up エージェントへの引き継ぎ点）

--- a/agent-first-meeting/src/agent_first_meeting/api.py
+++ b/agent-first-meeting/src/agent_first_meeting/api.py
@@ -7,11 +7,7 @@ from typing import AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from semantic_kernel.contents import (
-    FunctionCallContent,
-    FunctionResultContent,
-    StreamingTextContent,
-)
+from semantic_kernel.contents import StreamingTextContent
 from sse_starlette.sse import EventSourceResponse
 
 from agent_first_meeting.agent import build_agent, build_followup_agent
@@ -121,34 +117,36 @@ async def generate(req: GenerateRequest) -> EventSourceResponse:
         document_url: str | None = None
         accumulated_text = ""
 
+        def _drain_tool_events() -> list[dict]:
+            """tracker が記録したツール進捗を SSE 形式に変換して取り出す.
+
+            SK 1.42 の invoke_stream では FunctionCall/Result が stream に流れない
+            ため、Filter(ToolResultTracker) が貯めたイベントをここでドレインする。
+            """
+            drained: list[dict] = []
+            while tracker.events:
+                ev_type, tool_name = tracker.events.pop(0)
+                drained.append(_sse(ev_type, {"name": tool_name}))
+            return drained
+
         try:
             yield _sse("thought", {"text": f"{agent_label}面談エージェントを起動中..."})
 
             async for chunk in agent.invoke_stream(messages=user_message):
+                # ツール呼び出し進捗を流す
+                for ev in _drain_tool_events():
+                    yield ev
                 message = chunk.message
                 for item in message.items:
-                    if isinstance(item, FunctionCallContent):
-                        yield _sse(
-                            "tool",
-                            {
-                                "name": item.function_name,
-                                "args": item.arguments or "",
-                            },
-                        )
-                    elif isinstance(item, FunctionResultContent):
-                        result_str = str(item.result)
-                        yield _sse(
-                            "tool_result",
-                            {
-                                "name": item.function_name,
-                                "result": result_str[:300],
-                            },
-                        )
-                    elif isinstance(item, StreamingTextContent):
+                    if isinstance(item, StreamingTextContent):
                         text = item.text or ""
                         if text:
                             accumulated_text += text
                             yield _sse("message", {"text": text})
+
+            # ループ後に残ったツールイベントを流し切る
+            for ev in _drain_tool_events():
+                yield ev
 
             # Filter から確実に document_url / meeting_id / invoked_tools を取得
             document_url = tracker.document_url

--- a/agent-first-meeting/src/agent_first_meeting/config.py
+++ b/agent-first-meeting/src/agent_first_meeting/config.py
@@ -28,6 +28,12 @@ class Settings(BaseSettings):
     blob_container: str = "generated-documents"
     blob_account_key: str | None = None  # 空なら DefaultAzureCredential を使う
 
+    # 提案資料の「自社商品 / 費用」スライドに入れる値。
+    # 既定はプレースホルダ（価格 0 = 「別途お見積もり」）にしてあり、
+    # 実際の商品・価格は .env で上書きする。コードに偽の金額を埋め込まない。
+    default_product_name: str = "弊社ソリューション"
+    default_product_price_jpy: int = 0
+
     # App
     app_log_level: str = "INFO"
     # CORS で受け付けるオリジン（カンマ区切り）。本番では Streamlit / フロントの

--- a/agent-first-meeting/src/agent_first_meeting/schemas.py
+++ b/agent-first-meeting/src/agent_first_meeting/schemas.py
@@ -1,4 +1,5 @@
 """API のリクエスト/レスポンス スキーマ."""
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -67,8 +68,10 @@ def to_user_message(req: GenerateRequest) -> str:
         if position_category
         else "不明（役職表記から判定できなかったので、あなたが判断してください）"
     )
+    today = datetime.now().strftime("%Y年%m月%d日")
     message = (
         f"以下の顧客の{status_label}に向けたアポ資料を作ってください。\n\n"
+        f"- 本日の日付：{today}（表紙やサブタイトルの年月はこの日付を基準にすること）\n"
         f"- 会社名：{req.company_name}\n"
         f"- 業種：{req.industry}\n"
         f"- 規模：{req.scale}\n"
@@ -81,7 +84,11 @@ def to_user_message(req: GenerateRequest) -> str:
         f"- 担当営業：{req.salesperson or '（未記入）'}\n"
         f"- 面談ステータス：{status_label}\n"
     )
-    # follow-up のときだけ「前回面談メモ」を渡す（初回には存在しない情報なので出さない）
+    # follow-up のときだけ「前回面談メモ」を渡す（初回には存在しない情報なので出さない）。
+    # メモはサーバ側で既に前回 outcomes として記録済みなので、ここでは提案の素材として渡す。
     if req.meeting_status == "followup":
-        message += f"- 前回面談メモ：{req.last_meeting_notes or '（未記入）'}\n"
+        message += (
+            f"- 前回面談メモ（※システムが前回 outcomes として記録済み）："
+            f"{req.last_meeting_notes or '（未記入）'}\n"
+        )
     return message

--- a/agent-first-meeting/src/agent_first_meeting/tools/_blob_sas.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/_blob_sas.py
@@ -1,0 +1,112 @@
+"""Blob のダウンロード URL（SAS 署名）を発行する共有ヘルパ.
+
+`document_gen.py`（生成時）と `customer_history.py`（履歴読み出し時の再署名）で
+共用する。SAS トークンは時限なので、永続データには blob 名だけを保存し、
+URL は読み出すたびにここで再発行する設計にすることで「保存した URL が失効して
+401 になる」問題を避ける。
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+from urllib.parse import unquote, urlparse
+
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import (
+    BlobSasPermissions,
+    BlobServiceClient,
+    UserDelegationKey,
+    generate_blob_sas,
+)
+
+from agent_first_meeting.config import settings
+
+logger = logging.getLogger(__name__)
+
+SAS_EXPIRY_HOURS = 24
+# User delegation key は最大 7 日有効。キャッシュして再利用し、
+# 有効期限の少し前に再取得することで Managed Identity のロール変更にも追従する。
+_DELEGATION_KEY_TTL_HOURS = 24
+_DELEGATION_KEY_REFRESH_MARGIN = timedelta(minutes=10)
+
+
+def make_blob_service_client() -> BlobServiceClient:
+    """account key があればキー認証、無ければ DefaultAzureCredential で接続する."""
+    if settings.blob_account_key:
+        return BlobServiceClient(
+            account_url=settings.blob_account_url,
+            credential=settings.blob_account_key,
+        )
+    return BlobServiceClient(
+        account_url=settings.blob_account_url,
+        credential=DefaultAzureCredential(),
+    )
+
+
+def extract_blob_name(url: str) -> str | None:
+    """SAS/クエリ付きの Blob URL から blob 名（コンテナ以下のパス）を取り出す.
+
+    例: https://acct.blob.core.windows.net/generated-documents/proposals/x.pptx?sig=...
+        -> "proposals/x.pptx"
+    コンテナ配下でなければ None。
+    """
+    if not url:
+        return None
+    path = urlparse(url).path  # /{container}/proposals/x.pptx
+    prefix = f"/{settings.blob_container}/"
+    if path.startswith(prefix):
+        return unquote(path[len(prefix):])
+    return None
+
+
+class BlobSasSigner:
+    """blob 名から時限ダウンロード URL を発行する. delegation key を短期キャッシュ."""
+
+    def __init__(self, service_client: BlobServiceClient | None = None) -> None:
+        self._svc = service_client or make_blob_service_client()
+        self._delegation_key: UserDelegationKey | None = None
+        self._delegation_key_expiry: datetime | None = None
+
+    def _get_user_delegation_key(self) -> UserDelegationKey:
+        now = datetime.now(timezone.utc)
+        if (
+            self._delegation_key is not None
+            and self._delegation_key_expiry is not None
+            and now + _DELEGATION_KEY_REFRESH_MARGIN < self._delegation_key_expiry
+        ):
+            return self._delegation_key
+
+        start = now - timedelta(minutes=5)  # クロックスキュー吸収
+        expiry = now + timedelta(hours=_DELEGATION_KEY_TTL_HOURS)
+        self._delegation_key = self._svc.get_user_delegation_key(
+            key_start_time=start,
+            key_expiry_time=expiry,
+        )
+        self._delegation_key_expiry = expiry
+        logger.info(
+            "BlobSasSigner: refreshed user delegation key, expires=%s",
+            expiry.isoformat(),
+        )
+        return self._delegation_key
+
+    def sign_blob_name(self, blob_name: str) -> str:
+        """blob 名に対して読み取り専用の SAS 付き URL を発行する."""
+        blob_client = self._svc.get_blob_client(
+            container=settings.blob_container, blob=blob_name
+        )
+        common_kwargs = dict(
+            account_name=self._svc.account_name,
+            container_name=settings.blob_container,
+            blob_name=blob_name,
+            permission=BlobSasPermissions(read=True),
+            expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
+        )
+        if settings.blob_account_key:
+            sas_token = generate_blob_sas(
+                **common_kwargs,
+                account_key=settings.blob_account_key,
+            )
+        else:
+            sas_token = generate_blob_sas(
+                **common_kwargs,
+                user_delegation_key=self._get_user_delegation_key(),
+            )
+        return f"{blob_client.url}?{sas_token}"

--- a/agent-first-meeting/src/agent_first_meeting/tools/_pptx_builder.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/_pptx_builder.py
@@ -7,9 +7,10 @@ from io import BytesIO
 
 from pptx import Presentation
 
-# 固定スライドのテンプレート文言（Phase 3 ではダミー値）
-DEFAULT_PRODUCT_NAME = "テスト商品"
-DEFAULT_PRODUCT_PRICE_JPY = 10
+# 「自社商品 / 費用」スライドの既定文言。実値は config（.env）で上書きする想定。
+# 価格 0 以下は「金額未設定」とみなし、偽の金額の代わりに「別途お見積もり」を出す。
+DEFAULT_PRODUCT_NAME = "弊社ソリューション"
+DEFAULT_PRODUCT_PRICE_JPY = 0
 AGENDA_ITEMS = [
     "1. ご挨拶",
     "2. 業界トレンドとお客様の課題",
@@ -66,13 +67,18 @@ def build_presentation_bytes(
         f"商品名：{product_name}\n本日はこちらの商品をご提案いたします。",
     )
 
-    # 6. 費用
+    # 6. 費用（価格未設定なら偽の金額を出さず「別途お見積もり」とする）
+    price_line = (
+        f"価格：{product_price_jpy:,} 円（税別）"
+        if product_price_jpy > 0
+        else "価格：別途お見積もり"
+    )
     _add_content_slide(
         prs,
         "費用について",
         (
             f"商品「{product_name}」のご提供価格\n"
-            f"価格：{product_price_jpy:,} 円（税別）\n"
+            f"{price_line}\n"
             "※ 詳細条件は別途ご相談のうえ決定いたします。"
         ),
     )

--- a/agent-first-meeting/src/agent_first_meeting/tools/customer_history.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/customer_history.py
@@ -1,12 +1,15 @@
 """顧客情報・面談履歴の取得プラグイン (Cosmos DB)."""
 import json
+import logging
 from typing import Annotated
 
 from semantic_kernel.functions import kernel_function
 
 from agent_first_meeting._azure_clients import make_cosmos_client, strip_internal
 from agent_first_meeting.config import settings
+from agent_first_meeting.tools._blob_sas import BlobSasSigner, extract_blob_name
 
+logger = logging.getLogger(__name__)
 
 class CustomerHistoryPlugin:
     """`customers` / `meetings` コンテナから顧客情報と過去面談を取得する SK プラグイン."""
@@ -15,6 +18,31 @@ class CustomerHistoryPlugin:
         db = make_cosmos_client().get_database_client(settings.cosmos_database)
         self._customers = db.get_container_client("customers")
         self._meetings = db.get_container_client("meetings")
+        # 履歴中の preMeetingDocumentUrl を読み出し時に再署名するための signer。
+        # Blob を使わない経路では作らないよう遅延初期化する。
+        self._signer: BlobSasSigner | None = None
+
+    def _refresh_document_url(self, meeting: dict) -> None:
+        """meeting の preMeetingDocumentUrl を、blob 名から新しい SAS URL に差し替える.
+
+        保存されている URL は SAS を落とした素の URL（または旧データでは失効 SAS 付き）
+        なので、blob 名から都度発行し直す。失敗しても履歴取得は止めない（best-effort）。
+        """
+        blob_name = meeting.get("documentBlob") or extract_blob_name(
+            meeting.get("preMeetingDocumentUrl") or ""
+        )
+        if not blob_name:
+            return
+        try:
+            if self._signer is None:
+                self._signer = BlobSasSigner()
+            meeting["preMeetingDocumentUrl"] = self._signer.sign_blob_name(blob_name)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "failed to re-sign preMeetingDocumentUrl (blob=%s)",
+                blob_name,
+                exc_info=True,
+            )
 
     @kernel_function(
         description=(
@@ -55,6 +83,8 @@ class CustomerHistoryPlugin:
                 partition_key=company_id,
             )
         ]
+        for meeting in meetings:
+            self._refresh_document_url(meeting)
 
         return json.dumps(
             {"customer": customer, "meetings": meetings},

--- a/agent-first-meeting/src/agent_first_meeting/tools/document_gen.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/document_gen.py
@@ -2,112 +2,31 @@
 
 Phase 3: 表紙 / 目次 / 対業界向け / 役職向け / 自社商品 / 費用 の 6 スライド構成。
 PPTX 組み立て本体は `_pptx_builder.build_presentation_bytes` に分離。
-本ファイルは「Blob アップロードと SAS 発行」に専念する。
+Blob アップロードと SAS 発行は `_blob_sas` に分離。本ファイルは両者の接続に専念する。
 """
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import (
-    BlobClient,
-    BlobSasPermissions,
-    BlobServiceClient,
-    UserDelegationKey,
-    generate_blob_sas,
-)
 from semantic_kernel.functions import kernel_function
 
 from agent_first_meeting.config import settings
+from agent_first_meeting.tools._blob_sas import (
+    BlobSasSigner,
+    make_blob_service_client,
+)
 from agent_first_meeting.tools._pptx_builder import build_presentation_bytes
 
 logger = logging.getLogger(__name__)
-
-SAS_EXPIRY_HOURS = 24
-# User delegation key は最大 7 日有効。
-# キャッシュして再利用し、有効期限の少し前に再取得する。
-_DELEGATION_KEY_TTL_HOURS = 24
-_DELEGATION_KEY_REFRESH_MARGIN = timedelta(minutes=10)
-
-
-def _make_blob_service_client() -> BlobServiceClient:
-    if settings.blob_account_key:
-        return BlobServiceClient(
-            account_url=settings.blob_account_url,
-            credential=settings.blob_account_key,
-        )
-    return BlobServiceClient(
-        account_url=settings.blob_account_url,
-        credential=DefaultAzureCredential(),
-    )
 
 
 class DocumentGenPlugin:
     """6 スライド構成の PowerPoint を生成し Blob にアップロードする SK プラグイン."""
 
     def __init__(self) -> None:
-        self._blob_service = _make_blob_service_client()
-        self._container = self._blob_service.get_container_client(
-            settings.blob_container
-        )
-        # Managed Identity 経路で user delegation SAS を発行するときの key キャッシュ
-        self._delegation_key: UserDelegationKey | None = None
-        self._delegation_key_expiry: datetime | None = None
-
-    def _get_user_delegation_key(self) -> UserDelegationKey:
-        """user delegation key を取得（短期キャッシュ付き）.
-
-        TTL いっぱいに長く保持すると Managed Identity のロール剥奪に追従できない
-        ため、_DELEGATION_KEY_TTL_HOURS で再取得して常に新しいキーを使う。
-        """
-        now = datetime.now(timezone.utc)
-        if (
-            self._delegation_key is not None
-            and self._delegation_key_expiry is not None
-            and now + _DELEGATION_KEY_REFRESH_MARGIN < self._delegation_key_expiry
-        ):
-            return self._delegation_key
-
-        start = now - timedelta(minutes=5)  # クロックスキュー吸収
-        expiry = now + timedelta(hours=_DELEGATION_KEY_TTL_HOURS)
-        self._delegation_key = self._blob_service.get_user_delegation_key(
-            key_start_time=start,
-            key_expiry_time=expiry,
-        )
-        self._delegation_key_expiry = expiry
-        logger.info(
-            "DocumentGenPlugin: refreshed user delegation key, expires=%s",
-            expiry.isoformat(),
-        )
-        return self._delegation_key
-
-    def _build_download_url(self, blob_client: BlobClient) -> str:
-        """アップロードした Blob のダウンロード URL を返す.
-
-        - blob_account_key がある場合：account-key SAS を付与した時限 URL
-        - 無い場合（Managed Identity / DefaultAzureCredential 想定）：
-          user delegation key ベースの SAS を発行する。素の Blob URL を返すと
-          匿名アクセスがコンテナで無効化されているケースで 401 になる。
-        """
-        common_kwargs = dict(
-            account_name=self._blob_service.account_name,
-            container_name=settings.blob_container,
-            blob_name=blob_client.blob_name,
-            permission=BlobSasPermissions(read=True),
-            expiry=datetime.now(timezone.utc) + timedelta(hours=SAS_EXPIRY_HOURS),
-        )
-        if settings.blob_account_key:
-            sas_token = generate_blob_sas(
-                **common_kwargs,
-                account_key=settings.blob_account_key,
-            )
-        else:
-            sas_token = generate_blob_sas(
-                **common_kwargs,
-                user_delegation_key=self._get_user_delegation_key(),
-            )
-        return f"{blob_client.url}?{sas_token}"
+        svc = make_blob_service_client()
+        self._signer = BlobSasSigner(svc)
+        self._container = svc.get_container_client(settings.blob_container)
 
     @kernel_function(
         description=(
@@ -149,10 +68,12 @@ class DocumentGenPlugin:
             cover_subtitle=cover_subtitle,
             industry_body=industry_body,
             position_body=position_body,
-            # product / cost は固定値（Phase 3 ではダミー）
+            product_name=settings.default_product_name,
+            product_price_jpy=settings.default_product_price_jpy,
         )
 
         blob_name = f"proposals/{uuid.uuid4().hex}.pptx"
         blob_client = self._container.get_blob_client(blob_name)
         blob_client.upload_blob(pptx_bytes, overwrite=True)
-        return self._build_download_url(blob_client)
+        # 即時ダウンロード用に時限 SAS 付き URL を返す（永続保存は meeting_record 側で blob 名に正規化）
+        return self._signer.sign_blob_name(blob_name)

--- a/agent-first-meeting/src/agent_first_meeting/tools/meeting_record.py
+++ b/agent-first-meeting/src/agent_first_meeting/tools/meeting_record.py
@@ -20,6 +20,7 @@ from agent_first_meeting._azure_clients import make_cosmos_client, strip_interna
 from agent_first_meeting._company_id import deterministic_company_id
 from agent_first_meeting._meeting_select import select_target_meeting
 from agent_first_meeting.config import settings
+from agent_first_meeting.tools._blob_sas import extract_blob_name
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,13 @@ class MeetingRecordPlugin:
         now_iso = datetime.now(timezone.utc).isoformat()
         initial_round = self._estimate_initial_round(company_id)
 
+        # SAS トークンは時限なので、永続データには blob 名だけを保存する。
+        # 履歴を読むときに customer_history が SAS を再発行する（失効 URL を残さない）。
+        document_blob = extract_blob_name(document_url)
+        # preMeetingDocumentUrl は「失効したトークンを誤って信頼させない」よう
+        # クエリ（SAS）を落とした素の Blob URL を保存する。
+        bare_url = document_url.split("?", 1)[0] if document_url else document_url
+
         # round 番号を +1 しつつリトライ（並行 create で 409 が返ったら次の番号に進む）
         for round_num in range(initial_round, initial_round + _MAX_ROUND_RETRY):
             record = {
@@ -113,7 +121,8 @@ class MeetingRecordPlugin:
                 "round": round_num,
                 "scheduledAt": now_iso,
                 "status": "scheduled",
-                "preMeetingDocumentUrl": document_url,
+                "preMeetingDocumentUrl": bare_url,
+                "documentBlob": document_blob,
                 "proposedTitle": proposed_title,
                 "outcomes": None,
                 "nextActions": next_actions,

--- a/agent-first-meeting/tests/test_pptx_builder.py
+++ b/agent-first-meeting/tests/test_pptx_builder.py
@@ -81,22 +81,23 @@ def test_position_body_renders_role_specific_points():
 
 
 def test_product_slide_uses_default_product_name():
-    """自社商品スライドに既定の商品名（テスト商品）が入ること."""
+    """自社商品スライドに既定の商品名（プレースホルダ）が入ること."""
     prs = _open_generated()
     product_slide = prs.slides[4]
     body_text = product_slide.placeholders[1].text
     assert DEFAULT_PRODUCT_NAME in body_text
-    assert DEFAULT_PRODUCT_NAME == "テスト商品"
+    # 偽の商品名（テスト商品）を埋め込まないこと
+    assert DEFAULT_PRODUCT_NAME != "テスト商品"
 
 
-def test_cost_slide_includes_default_price():
-    """費用スライドに既定価格（10 円）が入ること."""
+def test_cost_slide_omits_fake_price_when_unset():
+    """既定価格 0 のときは偽の金額を出さず「別途お見積もり」にすること."""
     prs = _open_generated()
     cost_slide = prs.slides[5]
     body_text = cost_slide.placeholders[1].text
-    assert DEFAULT_PRODUCT_PRICE_JPY == 10
-    assert "10" in body_text
-    assert "円" in body_text
+    assert DEFAULT_PRODUCT_PRICE_JPY == 0
+    assert "別途お見積もり" in body_text
+    assert "10 円" not in body_text
     assert DEFAULT_PRODUCT_NAME in body_text
 
 


### PR DESCRIPTION
## 概要
過去面談データから資料を作る本来のフローに対するレビュー指摘のうち、**develop(PR #22) で未対応だった net-new の改善のみ**を追加します。重複していた指摘（outcomes 順序・partial・業種フィルタ）は develop 版を採用し、本 PR では再実装しません。

## 変更内容（net-new）
- **失効URL対策**: 面談レコードに SAS を外した素 URL + `documentBlob`（blob 名）を保存し、`get_customer_history` が**読み出し時に SAS を再発行**。保存済み URL が 24h で失効して 401 になる問題を解消（共有 `_blob_sas.py` を新設、`document_gen` も共用）。
- **進捗の実配信(#6)**: SK 1.42 で `invoke_stream` に流れない FunctionCall/Result の代わりに、Filter(`ToolResultTracker`) が貯めたイベントを API がドレインして `tool`/`tool_result` SSE を実際に配信。
- **偽価格の排除(#7)**: 自社商品/費用スライドを config 化（`DEFAULT_PRODUCT_NAME` / `DEFAULT_PRODUCT_PRICE_JPY`）。既定はプレースホルダで、価格 0 は「別途お見積もり」表示。顧客向け資料に偽の ¥10 が出ない。
- **表紙日付(#8)**: 現在日付をプロンプトへ注入し、表紙の年月を正しく出す。

## develop 版を採用（本PRでは触らない）
- #1 outcomes 順序 → develop はプロンプトで「前回 round を明示し save より先に記録」
- #2 partial ステータス → develop に同等実装あり
- #4 業種フィルタ → develop の双方向 CONTAINS + 全業種（こちらが堅牢）

## 動作確認
- 実 Azure（Cosmos / Azure OpenAI gpt-4.1 / Blob）で **初回→followup の E2E** を実走:
  - followup で前回 round に outcomes 記録 / 新 round は outcomes=null（順序正しい）
  - 履歴 URL が読み出し時に再署名される
  - tool/tool_result の進捗 SSE が配信される
  - 生成 PPTX の費用スライド = 「別途お見積もり」、表紙 = 現在年月
- ユニットテスト **96 件パス**

## 備考
- #1 は develop のプロンプト方式（LLM が round_num を明示）を採用。より堅牢な「サーバ側で確定記録」案も検討したが、merged 済みの develop 方式を尊重。将来ハードニングするなら別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)