### PR TITLE
fix: followup の前回outcomes記録をサーバ側で確定（LLM非依存に強化）

### DIFF
--- a/agent-first-meeting/src/agent_first_meeting/agent.py
+++ b/agent-first-meeting/src/agent_first_meeting/agent.py
@@ -120,31 +120,25 @@ FOLLOWUP_AGENT_INSTRUCTIONS = """\
 初回との決定的な違いは「前回までに起きたこと（outcomes）と積み残し（nextActions）を
 必ず踏まえ、継続提案として一歩進める」点です。以下の流れで動いてください。
 
+なお「前回面談メモ」は **システム側が既に前回 outcomes として記録済み** です。
+あなたは **record_meeting_outcomes を呼ばないでください**（呼ぶと今回作る新しい
+レコードに誤って書き込まれます）。前回実績は get_customer_history の outcomes で参照します。
+
 1. **get_customer_history** で過去の取引履歴を必ず取得する
    - meetings 配列が空なら継続提案は成り立たない。
      「初回面談を先に実施してください」と伝えて終了する
    - meetings は round 降順。直近 meeting の round / proposedTitle / outcomes /
      nextActions / preMeetingDocumentUrl を読み取る
+   - outcomes も nextActions も無ければ、前回は資料生成のみで実績未確定とみなして
+     慎重に提案する
 
-2. 入力に「前回面談メモ」がある場合は、**record_meeting_outcomes** で
-   step1 で読み取った直近 meeting の round を **round_num に必ず明示指定して**
-   outcomes を保存する。この記録は **step5/6 の資料生成・保存より先に** 行うこと
-   - round_num を省略すると「最新の meeting」が対象になるが、step6 で今回の
-     新規レコード（outcomes=null）を先に作ってしまうと、そちらに前回メモが
-     書き込まれて前回実績が永久に確定しなくなる。これを防ぐため round_num は
-     前回 round の値を必ず渡す
-   - これにより「前回の成果」が確定し、今回の提案の根拠になる
-   - メモが「（未記入）」または空なら呼ばない。その場合は履歴に既にある
-     outcomes をそのまま根拠に使う（outcomes も nextActions も無ければ、
-     前回は資料生成のみで実績未確定とみなして慎重に提案する）
-
-3. 必要に応じて **fetch_url_text** で HP を再取得し、前回からの事業状況の
+2. 必要に応じて **fetch_url_text** で HP を再取得し、前回からの事業状況の
    変化（新規事業・プレスリリース等）を拾う（URL が無ければ飛ばす）
 
-4. 前回の nextActions を「解決・前進させる」観点で今回の論点を設計する。
+3. 前回の nextActions を「解決・前進させる」観点で今回の論点を設計する。
    裏付けが欲しければ **search_similar_cases** で追加事例を取得する
 
-5. **generate_pptx** で 6 スライド構成の継続提案資料を生成する
+4. **generate_pptx** で 6 スライド構成の継続提案資料を生成する
    - **cover_title**: 継続提案だと分かるタイトル。前回テーマからの前進を示す
      （例: 「技能継承 DX 第2次ご提案：PoC から本格導入へ」）
    - **cover_subtitle**: 「<会社名> 様向け / <年月> / 担当: <営業名>（第<round+1>回）」
@@ -153,11 +147,11 @@ FOLLOWUP_AGENT_INSTRUCTIONS = """\
    - **position_body**: 前回 nextActions への回答・進捗を、取引相手の役職に
      響く形で 3〜5 行の箇条書き（改行区切り）
 
-6. **save_meeting_record** で今回のレコードを保存する（round は自動採番）
+5. **save_meeting_record** で今回のレコードを保存する（round は自動採番）
    - next_actions には「今回の面談で確認・合意したい次の一手」を入れる
-     （今回の outcomes は後日また record_meeting_outcomes で埋まる契約）
+     （今回の outcomes は面談実施後にシステム側で記録される契約）
 
-7. 最後に営業担当者へ簡潔に報告する
+6. 最後に営業担当者へ簡潔に報告する
    - 前回（round / テーマ / outcomes）からの差分
    - 今回の継続提案タイトルと、その根拠（前回 nextActions / 参照事例）
    - 生成資料の URL

--- a/agent-first-meeting/src/agent_first_meeting/api.py
+++ b/agent-first-meeting/src/agent_first_meeting/api.py
@@ -15,6 +15,7 @@ from agent_first_meeting.config import settings
 from agent_first_meeting.logging_config import setup_logging
 from agent_first_meeting.schemas import GenerateRequest, to_user_message
 from agent_first_meeting.tools.customer_history import CustomerHistoryPlugin
+from agent_first_meeting.tools.meeting_record import MeetingRecordPlugin
 
 PPTX_URL_PATTERN = re.compile(r"https://[^\s)\]」]+?\.pptx(?:\?[^\s)\]」]*)?")
 
@@ -61,25 +62,26 @@ def _sse(event: str, payload: dict) -> dict:
 
 def _check_followup_precondition(
     history_plugin: CustomerHistoryPlugin, company_name: str
-) -> tuple[bool, str | None]:
-    """follow-up モードで前提となる過去面談があるか確認する.
+) -> tuple[bool, str | None, int | None]:
+    """follow-up モードで前提となる過去面談があるか確認し、直近 round を返す.
 
     Returns:
-        (ok, error_message). ok=False のとき error_message に理由が入る。
+        (ok, error_message, latest_round). ok=False のとき error_message に理由。
     """
     history_json = history_plugin.get_customer_history(company_name)
     try:
         history = json.loads(history_json)
     except json.JSONDecodeError as e:
         logger.exception("invalid history json: %s", e)
-        return False, "履歴の取得に失敗しました"
+        return False, "履歴の取得に失敗しました", None
     meetings = history.get("meetings") or []
     if not meetings:
         return False, (
             f"「{company_name}」の過去面談が見つかりません。"
             "「初回」を選択して初回面談を先に実施してください。"
-        )
-    return True, None
+        ), None
+    latest_round = max((m.get("round", 0) for m in meetings), default=0)
+    return True, None, latest_round
 
 
 @app.post("/api/first-meeting/generate")
@@ -94,7 +96,7 @@ async def generate(req: GenerateRequest) -> EventSourceResponse:
         # meeting_status をトリガーにしてエージェントを分岐（リクエスト毎に build）
         if req.meeting_status == "followup":
             # 早期 return: 過去面談がなければ followup は意味をなさない
-            ok, reason = _check_followup_precondition(
+            ok, reason, latest_round = _check_followup_precondition(
                 app.state.history_plugin, req.company_name
             )
             if not ok:
@@ -108,6 +110,28 @@ async def generate(req: GenerateRequest) -> EventSourceResponse:
                     },
                 )
                 return
+
+            # 前回実績メモは「エージェント実行前」に、直近 round を明示してサーバ側で
+            # 記録する。LLM の呼び出し順に依存させると、今回作る新レコード（最大 round）
+            # に誤って書き込まれて前回実績が確定しなくなるため、ここで決定的に確定させる。
+            notes = req.last_meeting_notes.strip()
+            if notes:
+                yield _sse(
+                    "thought",
+                    {"text": f"前回面談（round {latest_round}）の実績メモを記録中..."},
+                )
+                try:
+                    MeetingRecordPlugin().record_meeting_outcomes(
+                        req.company_name, notes, latest_round or 0
+                    )
+                    yield _sse("tool_result", {"name": "record_meeting_outcomes"})
+                except Exception:  # noqa: BLE001
+                    logger.exception("failed to record previous outcomes (continuing)")
+                    yield _sse(
+                        "thought",
+                        {"text": "前回実績メモの記録に失敗しました（処理は継続します）。"},
+                    )
+
             agent, tracker = build_followup_agent()
             agent_label = "2回目以降"
         else:


### PR DESCRIPTION
## 概要
followup の「前回 outcomes 記録」を **LLM 非依存のサーバ側確定方式**に強化します。

## 背景
PR #22/#23 では、前回 outcomes の記録をエージェントへのプロンプト指示（「直近 round を明示し、save より先に record_meeting_outcomes を呼べ」）に委ねていました。動作はしますが、LLM が呼び出し順や round_num を誤ると、**今回作る新レコード（最大 round）に前回メモが書き込まれ、前回実績が永久に確定しない**リスクが残ります（当初レビューで挙げた #1 の本質的懸念）。

## 変更内容
- **API 側で followup 実行前に確定記録**: 前提チェックで取得した履歴の直近 round を明示し、`record_meeting_outcomes` をサーバから呼ぶ。新レコード作成より前なので、必ず「前回」meeting に outcomes が入る。
- **エージェント指示から該当ツールを除外**: followup の instructions から `record_meeting_outcomes` 呼び出し手順を削除し「呼ばないこと」を明示。前回実績は `get_customer_history` の outcomes で参照。

## 動作確認
- 実 Azure で 初回→followup を実走:
  - followup の SSE 先頭で `record_meeting_outcomes`（サーバ側）が走り、**エージェントのツール列には当該ツールが出現しない**（LLM 非依存を確認）
  - round1=`done`+outcomes 記録 / round2=`outcomes:null`（正しい順序）
- ユニットテスト **96 件パス**

## 備考
- 変更は `api.py`（前提チェックが直近 round を返す＋実行前記録）と `agent.py`（followup 指示）の 2 ファイルのみ。#2/#3/#4/#6/#7/#8 は既存のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)