### PR TITLE
docs: 動作フロー(flow.md)追加＋api.md を現行実装に同期

### DIFF
--- a/agent-first-meeting/docs/api.md
+++ b/agent-first-meeting/docs/api.md
@@ -2,7 +2,10 @@
 
 ## POST /api/first-meeting/generate
 
-初回面談向けアポ資料を生成する。エージェントの思考プロセスは SSE でストリーミングされる。
+初回・2回目以降のアポ/継続提案資料を生成する**単一の窓口**。`meetingStatus` でモードを切り替える。
+エージェントの進捗・最終レポートは SSE（Server-Sent Events）でストリーミングされる。
+
+> 実行フローの図解（初回/followup のシーケンス、ファイル・ツール単位）は [flow.md](./flow.md) を参照。
 
 ### リクエスト
 
@@ -12,7 +15,12 @@
   "industry": "製造業",
   "scale": "中小企業",
   "knownInfo": "DX推進したいが何から手を付けるか不明",
-  "salesperson": "佐々木"
+  "salesperson": "佐々木",
+  "homepageUrl": "https://example.co.jp",
+  "contactName": "山田太郎",
+  "contactDepartment": "経営企画部",
+  "contactPosition": "部長",
+  "meetingStatus": "first"
 }
 ```
 
@@ -23,55 +31,48 @@
 | `scale` | string | ✅ | 企業規模（例: 中小企業, 大企業） |
 | `knownInfo` | string | - | 事前に分かっている課題感などのフリーテキスト |
 | `salesperson` | string | - | 担当営業名 |
-| `homepageUrl` | string | - | 顧客公式 HP。本文を取得して提案根拠に使う |
+| `homepageUrl` | string | - | 顧客公式 HP。本文を取得して提案根拠に使う（**取得はこのホストに限定**） |
 | `contactName` / `contactDepartment` / `contactPosition` | string | - | 取引相手の氏名 / 部署 / 役職 |
 | `meetingStatus` | string | - | `"first"`（既定）= 初回、`"followup"` = 2回目以降 |
 | `lastMeetingNotes` | string | - | （followup 時）前回面談の実績メモ。詳細は下記 |
 
-> このエンドポイントは **初回（first）と 2回目以降（followup）の両モード** を `meetingStatus` で切り替える単一窓口です。
+### レスポンス（SSE イベント）
 
-### レスポンス（SSE）
+| event | data | 説明 |
+|---|---|---|
+| `thought` | `{"text": "..."}` | 進捗メッセージ（起動中・サーバ側記録中など） |
+| `tool` | `{"name": "ツール名"}` | ツール呼び出し開始（Filter 捕捉分をチャンク間で配信） |
+| `tool_result` | `{"name": "ツール名"}` | ツール完了 |
+| `message` | `{"text": "..."}` | エージェントの最終レポート（逐次） |
+| `done` | 下記 | 完了（成功 / 部分成功 / エラー） |
 
-```
-event: thought      data: {"step":"類似事例を探します"}
-event: tool         data: {"name":"search_similar_cases","args":{...}}
-event: tool_result  data: {"hits": 5}
-event: thought      data: {"step":"アウトラインを作成中"}
-...
-event: done         data: {
+`done` の `data`（成功・部分成功時）:
+
+```json
+{
   "status": "success",
   "data": {
-    "documentUrl": "https://....pptx",
-    "meetingId": "mtg_xxx",
-    "caseReferences": [{"id":"case_001","title":"..."}],
-    "generatedAt": "2026-05-09T..."
+    "documentUrl": "https://....pptx?<SAS>",
+    "message": "（エージェントの最終レポート全文）",
+    "invokedTools": ["generate_pptx", "get_customer_history", "save_meeting_record", "search_similar_cases"],
+    "meetingId": "mtg_cus_xxxx_0001",
+    "warnings": []
   },
   "error": null
 }
 ```
 
-event: thought      data: {"step":"類似事例を探します"}
-event: tool         data: {"name":"search_similar_cases","args":{...}}
-event: tool_result  data: {"hits": 5}
-event: thought      data: {"step":"アウトラインを作成中"}
-...
-event: done         data: {
-  "status": "success",
-  "data": {
-    "documentUrl": "https://....pptx",
-    "meetingId": "mtg_xxx",
-    "caseReferences": [
-      {
-        "id": "doc_001",
-        "title": "技能継承課題に対する AI ナレッジベース導入",
-        "type": "proposal",
-        "industry": "製造業"
-      }
-    ],
-    "generatedAt": "2026-05-09T..."
-  },
-  "error": null
-}
+#### `status` の意味
+
+| status | 条件 |
+|---|---|
+| `success` | 資料が生成され、必須ツールがすべて呼ばれた |
+| `partial` | 資料は生成されたが必須ツールが欠けている（`warnings` に詳細）。完全成功にすると次回 followup の前提が静かに壊れるため区別する |
+| `error` | 資料が生成されなかった（`error.code = "NoDocument"`）等 |
+
+必須ツール:
+- 初回: `generate_pptx`, `save_meeting_record`
+- followup: `get_customer_history`, `generate_pptx`, `save_meeting_record`
 
 ### エラー時
 
@@ -79,32 +80,28 @@ event: done         data: {
 {
   "status": "error",
   "data": null,
-  "error": {
-    "code": "...",
-    "message": "..."
-  }
+  "error": { "code": "NoPreviousMeeting", "message": "..." }
 }
 ```
 
+代表的な `error.code`: `NoPreviousMeeting`（followup で過去面談なし）、`NoDocument`（資料未生成）、その他は例外型名。
+
 ## follow-up（2回目以降）モード
 
-`meetingStatus: "followup"` を指定すると、継続提案用のエージェントが起動する。
+`meetingStatus: "followup"` で継続提案エージェントが起動する。
 
 ### 前提チェック
+過去の面談（`meetings`）が 1 件も無い顧客に followup を呼ぶと、**エージェントを起動せず**即座に
+`error.code = "NoPreviousMeeting"` を返す。先に初回（first）を実施しておく必要がある。
 
-過去の面談（`meetings`）が 1 件も無い顧客に対して followup を呼ぶと、エージェントを
-起動せず即座にエラーを返す（`error.code = "NoPreviousMeeting"`）。先に初回（first）を
-実施しておく必要がある。
+### 前回実績（outcomes）の記録 — サーバ側で確定
+`lastMeetingNotes` に前回面談で起きたこと（反応・合意事項・宿題など）を渡すと、**API がエージェント
+実行前に、履歴の直近 round を明示して `record_meeting_outcomes` を呼び**、前回 meeting の `outcomes`
+を確定し `status` を `done` に更新する。
 
-### 前回実績（outcomes）の記録
-
-`lastMeetingNotes` に前回面談で実際に起きたこと（反応・合意事項・宿題など）を渡すと、
-エージェントが **`record_meeting_outcomes`** ツールで直近 meeting の `outcomes` を埋め、
-`status` を `done` に更新する。これにより「前回の成果を踏まえた継続提案」が成立する。
-
+- これは **LLM の呼び出し順に依存させない**ための設計（エージェント自身は `record_meeting_outcomes` を呼ばない）。新しい面談レコードに前回メモが誤って書き込まれる事故を防ぐ。
 - `lastMeetingNotes` を省略した場合は、既に `meetings` に記録済みの `outcomes` を根拠に使う。
-- 今回生成した meeting の `outcomes` は `null` で保存され、次回の followup 呼び出し時に
-  改めて `lastMeetingNotes` 経由で埋められる契約。
+- 今回生成した meeting の `outcomes` は `null` で保存され、次回 followup 呼び出し時に改めて確定される契約。
 
 ### リクエスト例（followup）
 
@@ -119,5 +116,12 @@ event: done         data: {
 }
 ```
 
-`done` イベントの `data.invokedTools` には、初回と異なり `get_customer_history` が必須で含まれる
-（`lastMeetingNotes` を渡した場合は `record_meeting_outcomes` も呼ばれる）。
+## セキュリティ・運用上の挙動
+
+- **資料URLの再署名**: 面談レコードには SAS を外した素URL + blob 名を保存し、`get_customer_history`
+  が履歴を返すたびに SAS を再発行する（保存済みURLが失効して 401 になるのを防ぐ）。
+- **HP取得の限定**: `fetch_url_text` はリクエストで指定された顧客HPのホスト宛のみ許可し、取得本文は
+  「信頼できない外部データ」として扱う（プロンプトインジェクションでの別ホストへのデータ持ち出しを抑止）。
+  `WEB_FETCH_ENABLED=false` で取得ツール自体を無効化できる。
+- **認証**: 公開フロントエンド（Streamlit）はアクセスコードで保護（`APP_ACCESS_CODE`、デプロイ設定）。
+  バックエンド API は internal ingress（インターネット非公開）。

--- a/agent-first-meeting/docs/flow.md
+++ b/agent-first-meeting/docs/flow.md
@@ -1,0 +1,93 @@
+# 動作フロー（初回 / 2回目以降）
+
+`POST /api/first-meeting/generate` は単一の窓口で、`meetingStatus`（`first` / `followup`）
+によって振る舞いを切り替える。応答は SSE（Server-Sent Events）でストリーミングされる。
+ここでは**どのファイル・ツールが何を読み書きするか**を実装に沿って示す。
+
+## 関係するファイルと役割
+
+| ファイル | 役割 |
+|---|---|
+| `frontend/main.py` | Streamlit UI。アクセスコード・ゲート → 入力フォーム → API を SSE 呼び出し、進捗とDLボタンを表示。連続実行クールダウン。 |
+| `src/agent_first_meeting/api.py` `generate()` | first/followup 分岐、followup の前提チェック、**前回 outcomes のサーバ側記録**、SSE 配信、`status` 判定（success/partial/error） |
+| `src/agent_first_meeting/schemas.py` `to_user_message()` | リクエストを LLM 向けプロンプトに整形（役職カテゴリの前処理・本日日付の注入） |
+| `src/agent_first_meeting/agent.py` | `build_agent` / `build_followup_agent`、instructions、ツール呼び出しを捕捉する Filter `ToolResultTracker` |
+| `tools/customer_history.py` | Cosmos `customers` / `meetings` 読込。履歴中の資料URLを**読み出し時に SAS 再署名** |
+| `tools/case_search.py` | OpenAI 埋め込み + Cosmos `chunks` のベクトル検索（業種は双方向 CONTAINS + 全業種を常時対象） |
+| `tools/web_fetch.py` | 顧客 HP 取得。**入力された顧客HPのホストに限定** + SSRF ガード + 「信頼できない外部データ」明示 |
+| `tools/document_gen.py` | python-pptx で6スライド生成 → Blob アップロード → SAS 付きURL（永続保存は blob 名） |
+| `tools/meeting_record.py` | `save_meeting_record`（新規 round, `outcomes=null`, blob 名保存）/ `record_meeting_outcomes`（前回 round を確定） |
+| `_azure_clients.py` / `tools/_blob_sas.py` | Cosmos / OpenAI / Blob クライアント生成（キー or Managed Identity）、SAS 発行 |
+
+## 初回（first）
+
+```mermaid
+sequenceDiagram
+    participant U as 営業担当(Streamlit)
+    participant API as api.generate (FastAPI/SSE)
+    participant AG as Agent (Semantic Kernel / gpt-4.1)
+    participant Cos as Cosmos DB
+    participant AO as Azure OpenAI
+    participant Blob as Blob Storage
+
+    U->>API: POST /api/first-meeting/generate (meetingStatus=first)
+    Note over API: to_user_message() で整形（本日日付注入）<br/>build_agent(allowed_fetch_host=HPホスト)
+    API-->>U: SSE thought「初回面談エージェントを起動中」
+    AG->>Cos: get_customer_history（新規なら customer=null）
+    opt 公式HPあり
+        AG->>AG: fetch_url_text（入力ホスト限定・untrusted扱い）
+    end
+    AG->>AO: search_similar_cases（クエリ埋め込み）
+    AG->>Cos: ベクトル検索（chunks）
+    AG->>Blob: generate_pptx（6枚生成→アップロード→SAS URL）
+    AG->>Cos: save_meeting_record（meetings: outcomes=null, blob名保存）
+    Note over API,AG: Filter(ToolResultTracker) が tool/結果/documentUrl/meetingId を捕捉
+    API-->>U: SSE tool / tool_result（チャンク間でドレイン）, message（逐次）
+    API-->>U: SSE done {status: success|partial, documentUrl, meetingId, invokedTools, warnings}
+```
+
+- 必須ツール（`REQUIRED_TOOLS_FIRST`）: `generate_pptx`, `save_meeting_record`。
+- 資料は出たが必須ツールが欠けた場合は `status=partial`（警告付き）。資料が無ければ `error`（`NoDocument`）。
+
+## 2回目以降（followup）
+
+```mermaid
+sequenceDiagram
+    participant U as 営業担当(Streamlit)
+    participant API as api.generate (FastAPI/SSE)
+    participant AG as Agent (Semantic Kernel)
+    participant Cos as Cosmos DB
+    participant Blob as Blob Storage
+
+    U->>API: POST ... (meetingStatus=followup, lastMeetingNotes)
+    API->>Cos: _check_followup_precondition（get_customer_history で過去面談確認）
+    alt 過去面談なし
+        API-->>U: SSE done {status: error, code: NoPreviousMeeting}（エージェント起動せず終了）
+    else 過去面談あり（latest_round を取得）
+        opt lastMeetingNotes あり
+            API->>Cos: record_meeting_outcomes(前回 round を明示) ※サーバ側で確定
+            API-->>U: SSE thought / tool_result（record_meeting_outcomes）
+        end
+        Note over API: build_followup_agent(allowed_fetch_host)
+        AG->>Cos: get_customer_history（前回 outcomes / nextActions を参照）
+        opt HP 再取得
+            AG->>AG: fetch_url_text（ホスト限定）
+        end
+        AG->>Cos: search_similar_cases（必要に応じ）
+        AG->>Blob: generate_pptx（継続提案資料）
+        AG->>Cos: save_meeting_record（新 round, outcomes=null）
+        API-->>U: SSE tool / tool_result / message
+        API-->>U: SSE done {status: success|partial, documentUrl, meetingId, invokedTools, warnings}
+    end
+```
+
+**初回との決定的な違い**:
+- 前提チェックで過去面談が無ければ即エラー（`NoPreviousMeeting`）。
+- 前回実績（outcomes）の記録は **API（サーバ側）が前回 round を明示して確定**する（LLM の呼び出し順に依存しない）。エージェント自身は `record_meeting_outcomes` を呼ばない。
+- 必須ツール（`REQUIRED_TOOLS_FOLLOWUP`）: `get_customer_history`, `generate_pptx`, `save_meeting_record`。
+
+## データの読み書き（まとめ）
+
+- **読み取り**: `customers` / `meetings`（履歴）、`documents` / `chunks`（類似事例ベクトル検索）、外部HP（任意・ホスト限定）。
+- **書き込み**: Blob `generated-documents/proposals/*.pptx`、`customers`（決定的 companyId で upsert）、`meetings`（`mtg_{companyId}_{round:04d}`、409 リトライ採番。初回・followup とも `outcomes=null` で作成し、次回の followup 時にサーバ側で前回 round へ確定）。
+- **返却**: 24時間有効の SAS 付きダウンロードURL（永続データには blob 名のみ保存し、履歴読み出し時に都度再署名）。


### PR DESCRIPTION
## 概要
初回/2回目以降の動作フローのドキュメントを整備します。

- **`docs/flow.md`（新規）**: 初回・followup の **mermaid シーケンス図**（どのファイル・ツールが何を読み書きするか）＋関係ファイルの役割表＋データ読み書きまとめ。
- **`docs/api.md`（修正）**: 現行実装に同期。
  - SSE イベント形式を実体に合わせて記載（`thought`/`tool`/`tool_result`/`message`/`done`）
  - `status=partial` の追加、`done.data` の実フィールド（documentUrl/message/invokedTools/meetingId/warnings）
  - followup の **前回 outcomes はサーバ側で確定**（LLM非依存）に修正
  - SAS 再署名・HP取得のホスト限定・アクセスコードの運用注記を追加
  - 旧記述（`caseReferences` / `generatedAt` / エージェントが outcomes を呼ぶ等）を削除

秘密情報は含まない（スキャン済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)